### PR TITLE
"Reconsider judgement" corrected

### DIFF
--- a/src/main/definitions/contact-tribunal-applications.ts
+++ b/src/main/definitions/contact-tribunal-applications.ts
@@ -73,8 +73,8 @@ export const application: { [key: string]: Application } = {
     type: ApplicationType.A,
   },
   RECONSIDER_JUDGMENT: {
-    code: 'Reconsider judgment',
-    claimant: 'Reconsider judgment',
+    code: 'Reconsider judgement',
+    claimant: 'Reconsider judgement',
     url: 'apply-for-judgment-to-be-reconsidered',
     type: ApplicationType.B,
   },


### PR DESCRIPTION
"Reconsider judgement" key typo is corrected to "judgement" rather than "judgment" This is inline with app type keys used in et-sya-api for doc type tags


### Change description

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
