### PR TITLE
Prelogin_Error_Update

### DIFF
--- a/src/main/definitions/constants.ts
+++ b/src/main/definitions/constants.ts
@@ -323,7 +323,7 @@ export const RedisErrors = {
   FAILED_TO_CONNECT: 'Error when attempting to connect to Redis',
   FAILED_TO_SAVE: 'Error when attempting to save to Redis',
   FAILED_TO_RETRIEVE: 'Error when attempting to retrieve value from Redis',
-  FAILED_TO_RETRIEVE_PRE_LOGIN_URL: 'Error when attempting to retrieve preLoginUrl from Redis',
+  PRE_LOGIN_URL_NOT_FOUND: 'Pre login URL not found in Redis',
   CLIENT_NOT_FOUND: 'Redis client does not exist',
 } as const;
 

--- a/src/main/modules/oidc/index.ts
+++ b/src/main/modules/oidc/index.ts
@@ -125,9 +125,10 @@ export const idamCallbackHandler = async (req: AppRequest, res: Response, servic
     const preLoginUrl = await getPreLoginUrl(redisClient, guid);
     if (preLoginUrl) {
       return res.redirect(preLoginUrl);
+    } else {
+      return res.redirect(PageUrls.HOME);
     }
-    logger.error(RedisErrors.FAILED_TO_RETRIEVE_PRE_LOGIN_URL);
   } catch (err) {
-    logger.error(RedisErrors.FAILED_TO_RETRIEVE_PRE_LOGIN_URL);
+    return res.redirect(PageUrls.HOME);
   }
 };


### PR DESCRIPTION
### JIRA link

There is no JIRA link.

-----

### Change description

Do not log any error data in production if the pre-login URL is not found in the Redis server. Instead, automatically redirect to the home page if no pre-login data is found. Having no pre-login data in Redis, is not an error.

-----

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
