### PR TITLE
RET-5964, RET-5969

### DIFF
--- a/src/main/controllers/RespondentContestClaimController.ts
+++ b/src/main/controllers/RespondentContestClaimController.ts
@@ -69,7 +69,7 @@ export default class RespondentContestClaimController {
   public get = (req: AppRequest, res: Response): void => {
     const redirectUrl = setUrlLanguage(req, PageUrls.RESPONDENT_CONTEST_CLAIM);
     const userCase = req.session.userCase;
-    const respondentName = userCase.respondents[0].respondentName;
+    const respondentName = userCase.respondentName;
 
     // Updating the labels to include both yes1, no1 and respondentName, yes2, no2
     const radioButtonFields = this.form.getFormFields();

--- a/src/main/resources/locales/cy/translation/template.json
+++ b/src/main/resources/locales/cy/translation/template.json
@@ -18,7 +18,7 @@
   "signOut": "Allgofnodi",
   "logIn": "Mewngofnodi",
   "phaseBanner": {
-    "feedback": "Bydd eich adborth",
+    "feedback": "Bydd eich adborth (yn agor mewn tab newydd)",
     "smartSurveyFeedbackUrl": "https://www.smartsurvey.co.uk/s/ET_Feedback/?pageurl=",
     "additionalText": "yn ein helpu i wella’r gwasanaeth.",
     "languageToggle": "<a href=\"{currentUrl}{languageFlag}\" class=\"govuk-link language\">English</a>"

--- a/src/main/resources/locales/en/translation/template.json
+++ b/src/main/resources/locales/en/translation/template.json
@@ -18,7 +18,7 @@
   "signOut": "Sign out",
   "logIn": "Login",
   "phaseBanner": {
-    "feedback": "Your feedback",
+    "feedback": "Your feedback (opens in a new tab)",
     "smartSurveyFeedbackUrl": "https://www.smartsurvey.co.uk/s/ET_Feedback/?pageurl=",
     "additionalText": "helps us to improve this service.",
     "languageToggle": "<a href=\"{currentUrl}{languageFlag}\" class=\"govuk-link language\">Cymraeg</a>"

--- a/src/main/views/form/main/template.njk
+++ b/src/main/views/form/main/template.njk
@@ -74,7 +74,7 @@ if isLoggedIn %}
 
   {% set smartSurveyPageInfo = currentUrl | replace("/", "") %}
 
-  {% set phaseBarHtml = '<a class="govuk-link" href="' + phaseBanner.smartSurveyFeedbackUrl + smartSurveyPageInfo + '" target="_blank">' + phaseBanner.feedback + "</a> " + phaseBanner.additionalText %}
+  {% set phaseBarHtml = '<a class="govuk-link" rel="noreferrer noopener" href="' + phaseBanner.smartSurveyFeedbackUrl + smartSurveyPageInfo + '" target="_blank">' + phaseBanner.feedback + "</a> " + phaseBanner.additionalText %}
 
 
   {% if welshEnabled == null or welshEnabled === 'undefined' or welshEnabled === true %}

--- a/src/main/views/respondent-contest-claim.njk
+++ b/src/main/views/respondent-contest-claim.njk
@@ -15,7 +15,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       <span class="govuk-caption-xl">{{ sectionTitle.s3 }}</span>
-      <h1 class="govuk-heading-xl govuk-!-margin-bottom-4 ">{{ h1 + userCase.respondents[0].respondentName + h1Extra }}</h1>
+      <h1 class="govuk-heading-xl govuk-!-margin-bottom-4 ">{{ h1 + userCase.respondentName + h1Extra }}</h1>
 
       {% block form %}
         {% include "form/form.njk"%}


### PR DESCRIPTION
### JIRA link

https://tools.hmcts.net/jira/browse/RET-5969
https://tools.hmcts.net/jira/browse/RET-5964

### Change description

- Update logic on contest claim page to pick the current respondentName as opposed to the first respondent in the collection
- Update the link text to say 'Opens in a new tab' to fix accessibility issue

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
