### PR TITLE
RET-6098 - ET3 Submission Feedback Survey

### DIFF
--- a/src/main/controllers/ApplicationSubmittedController.ts
+++ b/src/main/controllers/ApplicationSubmittedController.ts
@@ -69,6 +69,7 @@ export default class ApplicationSubmittedController {
       et3FormId,
       et3FormName,
       contactTribunalUrl: PageUrls.CONTACT_TRIBUNAL + languageParam,
+      hideContactUs: true,
     });
   };
 }

--- a/src/main/resources/locales/cy/translation/application-submitted.json
+++ b/src/main/resources/locales/cy/translation/application-submitted.json
@@ -2,17 +2,22 @@
   "title": "Mae eich ymateb wedi cael ei gyflwyno",
   "titleText": "Mae eich ymateb wedi cael ei gyflwyno",
   "heading1": "Beth fydd yn digwydd nesaf",
-  "p1": "Dylech gael cadarnhad drwy e-bost gan swyddfa’r tribiwnlys sy’n prosesu eich ymateb o fewn 5 diwrnod gwaith. Efallai y bydd angen i chi wirio’ch ffolder junk.",
+  "p1": "Dylech dderbyn cadarnhad e-bost gan y swyddfa tribiwnlys sy’n prosesu eich ymateb o fewn 10 – 15 diwrnod gwaith.  Gall hyn ymestyn yn ystod cyfnodau prysur.",
   "heading2": "Manylion y cais",
   "caseNumber": "Rhif yr achos",
   "responseSubmitted": "Ymateb wedi'i gyflwyno",
   "downloadResponse": "Lawrlwytho eich ymateb",
   "attachments": "Atodiadau wedi’u cynnwys",
-  "heading3": "Cwestiynau am yr achos hwn",
+  "heading3": "Ar gyfer cwestiynau am broses y tribiwnlys cyflogaeth",
   "linkText": "Cysylltwch â'r tribiwnlys am yr achos (yn agor mewn tab newydd)",
-  "heading4": "Ar gyfer cwestiynau am broses y tribiwnlys cyflogaeth",
   "p3": "Ffoniwch un o ganolfannau cyswllt cwsmeriaid y Tribiwnlys Cyflogaeth. Ni allant roi cyngor cyfreithiol i chi.",
   "button": "Cau a dychwelyd i drosolwg o’r achos",
   "et3FormNotFound": "Ni ddaethpwyd o hyd i’r ffurflen ET3",
-  "noAttachments": "Dim dogfennau i'w hatodi"
+  "noAttachments": "Dim dogfennau i'w hatodi",
+  "survey": {
+    "titleText": "Rhowch eich adborth i ni",
+    "text": "byr hwn i helpu i wella'r gwasanaeth hwn i chi ac eraill.",
+    "linkText": "Llenwch yr arolwg",
+    "url": "https://www.smartsurvey.co.uk/s/SurveyExit/?lang=cy&service=Employment&party=resp"
+  }
 }

--- a/src/main/resources/locales/en/translation/application-submitted.json
+++ b/src/main/resources/locales/en/translation/application-submitted.json
@@ -2,17 +2,22 @@
   "title": "Your response has been submitted",
   "titleText": "Your response has been submitted",
   "heading1": "What happens next",
-  "p1": "You should receive email confirmation from the tribunal office processing your response within 5 working days. You may need to check your junk mail folder.",
+  "p1": "You should receive email confirmation from the tribunal office processing your response within 10 - 15 working days. This may extend during periods of high volumes.",
   "heading2": "Submission details",
   "caseNumber": "Case number",
   "responseSubmitted": "Response submitted",
   "downloadResponse": "Download your response",
   "attachments": "Attachments included",
-  "heading3": "For questions about this case",
+  "heading3": "For questions about the employment tribunal process",
   "linkText": "Contact the tribunal about the case (opens in new tab)",
-  "heading4": "For questions about the employment tribunal process",
   "p3": "Call one of our Employment Tribunal customer contact centres. They cannot give you legal advice.",
   "button": "Close and return to case overview",
   "et3FormNotFound": "ET3 form not found",
-  "noAttachments": "No documents to attach"
+  "noAttachments": "No documents to attach",
+  "survey": {
+    "titleText": "Give us your feedback",
+    "text": "to help improve this service for you and others.",
+    "linkText": "Complete this short survey",
+    "url": "https://www.smartsurvey.co.uk/s/SurveyExit/?lang=en&service=Employment&party=resp"
+  }
 }

--- a/src/main/views/application-submitted.njk
+++ b/src/main/views/application-submitted.njk
@@ -74,13 +74,42 @@
     <div class="govuk-body">
       <p><a href="{{ contactTribunalUrl }}" class="govuk-link" rel="noreferrer noopener" target="_blank"> {{ linkText }}</a></p>
     </div>
+      <p class="govuk-body">
+        {{ p3}}
+      </p>
 
-    <div class="govuk-button-group">
+      <ul class="govuk-list">
+        <li>
+          {{mainTelephone}}
+        </li>
+        <li>
+          {{welshTelephone}}
+        </li>
+        <li>
+          {{scotlandTelephone}}
+        </li>
+      </ul>
+      <p class="govuk-body">
+        <a href="https://www.gov.uk/call-charges" class="govuk-link" target="_blank">{{ contactCharges }}</a>
+      </p>
+
+      <div class="govuk-button-group">
       {{ govukButton({
         text: button,
         href: redirectUrl
       }) }}
     </div>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-border black-border govuk-!-padding-bottom-2">
+    <h2 class="govuk-heading-m">
+      {{ survey.titleText }}
+    </h2>
+    <p class="govuk-body">
+      <a href="{{ survey.url }}" class="govuk-link">{{ survey.linkText }}</a> {{ survey.text }}
+    </p>
   </div>
 </div>
 {% endblock %}

--- a/src/test/unit/controllers/AplicationSubmittedController.test.ts
+++ b/src/test/unit/controllers/AplicationSubmittedController.test.ts
@@ -117,6 +117,7 @@ describe('ApplicationSubmittedController', () => {
         et3FormId: documentId,
         et3FormName: documentName,
         contactTribunalUrl: '/contact-tribunal?lng=en',
+        hideContactUs: true,
       });
     });
 
@@ -156,6 +157,7 @@ describe('ApplicationSubmittedController', () => {
         et3FormId: documentId,
         et3FormName: documentNameWelsh,
         contactTribunalUrl: '/contact-tribunal?lng=cy',
+        hideContactUs: true,
       });
     });
 
@@ -170,6 +172,7 @@ describe('ApplicationSubmittedController', () => {
         TranslationKeys.APPLICATION_SUBMITTED,
         expect.objectContaining({
           welshEnabled: false,
+          hideContactUs: true,
           attachedDocuments:
             attachedDocuments +
             '<a href="getCaseDocument/' +
@@ -177,6 +180,81 @@ describe('ApplicationSubmittedController', () => {
             '" target="_blank">' +
             employerClaimDocumentName +
             '</a><br>',
+        })
+      );
+    });
+
+    it('should include contact phone numbers and survey information from translations', async () => {
+      (getFlagValue as jest.Mock).mockResolvedValue(true);
+      (getLanguageParam as jest.Mock).mockReturnValue('?lng=en');
+
+      const mockCommonTranslations = {
+        mainTelephone: 'Telephone: 0300 323 0196',
+        welshTelephone: 'Telephone: 0300 303 5176 (Welsh language)',
+        scotlandTelephone: 'Telephone: 0300 790 6234 (Scotland)',
+        contactCharges: 'Find out about call charges (opens in new tab)',
+      };
+
+      const mockSubmittedTranslations = {
+        p3: 'Call one of our Employment Tribunal customer contact centres. They cannot give you legal advice.',
+        survey: {
+          titleText: 'Give us your feedback',
+          text: 'to help improve this service for you and others.',
+          linkText: 'Complete this short survey',
+          url: 'https://www.smartsurvey.co.uk/s/SurveyExit/?lang=en&service=Employment&party=resp',
+        },
+      };
+
+      (req.t as unknown as jest.Mock).mockImplementation((key: string) => {
+        if (key === TranslationKeys.COMMON) {
+          return mockCommonTranslations;
+        }
+        if (key === TranslationKeys.APPLICATION_SUBMITTED) {
+          return mockSubmittedTranslations;
+        }
+        return {};
+      });
+
+      await controller.get(req, res);
+
+      expect(res.render).toHaveBeenCalledWith(
+        TranslationKeys.APPLICATION_SUBMITTED,
+        expect.objectContaining({
+          mainTelephone: 'Telephone: 0300 323 0196',
+          welshTelephone: 'Telephone: 0300 303 5176 (Welsh language)',
+          scotlandTelephone: 'Telephone: 0300 790 6234 (Scotland)',
+          contactCharges: 'Find out about call charges (opens in new tab)',
+          p3: 'Call one of our Employment Tribunal customer contact centres. They cannot give you legal advice.',
+          survey: {
+            titleText: 'Give us your feedback',
+            text: 'to help improve this service for you and others.',
+            linkText: 'Complete this short survey',
+            url: 'https://www.smartsurvey.co.uk/s/SurveyExit/?lang=en&service=Employment&party=resp',
+          },
+        })
+      );
+    });
+
+    it('should include hideContactUs flag to suppress template contact section', async () => {
+      (getFlagValue as jest.Mock).mockResolvedValue(true);
+      (getLanguageParam as jest.Mock).mockReturnValue('?lng=en');
+
+      (req.t as unknown as jest.Mock).mockImplementation((key: string) => {
+        if (key === TranslationKeys.COMMON) {
+          return {};
+        }
+        if (key === TranslationKeys.APPLICATION_SUBMITTED) {
+          return {};
+        }
+        return {};
+      });
+
+      await controller.get(req, res);
+
+      expect(res.render).toHaveBeenCalledWith(
+        TranslationKeys.APPLICATION_SUBMITTED,
+        expect.objectContaining({
+          hideContactUs: true,
         })
       );
     });


### PR DESCRIPTION
### JIRA link

https://tools.hmcts.net/jira/browse/RET-6098

### Change description

- Added the survey link once an ET3 response has been submitted
  - <img width="1204" height="290" alt="Screenshot 2025-12-09 at 08 11 10" src="https://github.com/user-attachments/assets/7ad0c337-f5e2-4049-8760-ff3c0392431d" />
  - <img width="1179" height="309" alt="Screenshot 2025-12-09 at 08 11 07" src="https://github.com/user-attachments/assets/4b9c97d1-37c7-4e58-84a5-6945cbeb635d" />
- Updated the guidance text and opened up the contact us details to almost mirror the ET1
  - <img width="1233" height="539" alt="Screenshot 2025-12-09 at 08 13 01" src="https://github.com/user-attachments/assets/e65b4e70-de80-4c47-a266-13b1088fc0b9" />
  - <img width="1155" height="289" alt="Screenshot 2025-12-09 at 08 12 58" src="https://github.com/user-attachments/assets/e03c918f-62f6-47e4-8141-e165a4f2706d" />
  - <img width="1166" height="317" alt="Screenshot 2025-12-09 at 08 12 54" src="https://github.com/user-attachments/assets/370b419d-b63a-4010-8ed1-1db2fcc71fe8" />
  - <img width="1214" height="535" alt="Screenshot 2025-12-09 at 08 12 52" src="https://github.com/user-attachments/assets/34d32674-82ff-4ba9-b451-023d4885a177" />



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
