### PR TITLE
fix(deps): update dependency govuk-frontend to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "express": "^4.22.1",
     "express-rate-limit": "^7.0.0",
     "express-session": "^1.18.2",
-    "govuk-frontend": "^5.11.0",
+    "govuk-frontend": "^6.0.0",
     "helmet": "^8.0.0",
     "i18next": "^24.0.0",
     "i18next-http-middleware": "^3.3.0",

--- a/src/main/assets/scss/main.scss
+++ b/src/main/assets/scss/main.scss
@@ -226,15 +226,10 @@ $lightgrey-panel: #d3d3d3;
   .govuk-header__logo {
     width: fit-content;
   }
-
-  .govuk-header__content {
-    float: right;
-    width: fit-content;
-  }
 }
 
-.govuk-header__navigation-item {
+.govuk-service-navigation__item {
   &:last-child {
-    float: right;
+    margin-left: auto;
   }
 }

--- a/src/main/definitions/links.ts
+++ b/src/main/definitions/links.ts
@@ -122,7 +122,7 @@ export const SectionIndexToEt3HubLinkNamesWithEmployersContractClaim: ET3HubLink
 //*************************************************************************//
 
 export const LinkColors = {
-  TURQUOISE: '--turquoise',
+  TEAL: '--teal',
   GREEN: '--green',
   BLUE: '--blue',
   RED: '--red',
@@ -155,13 +155,13 @@ export const enum LinkStatus {
 
 export const linkStatusColorMap = new Map<LinkStatus, string>([
   [LinkStatus.COMPLETED, LinkColors.GREEN],
-  [LinkStatus.SUBMITTED, LinkColors.TURQUOISE],
+  [LinkStatus.SUBMITTED, LinkColors.TEAL],
   [LinkStatus.OPTIONAL, LinkColors.BLUE],
-  [LinkStatus.VIEWED, LinkColors.TURQUOISE],
+  [LinkStatus.VIEWED, LinkColors.TEAL],
   [LinkStatus.NOT_VIEWED, LinkColors.RED],
   [LinkStatus.NOT_YET_AVAILABLE, LinkColors.GREY],
   [LinkStatus.WAITING_FOR_TRIBUNAL, LinkColors.GREY],
-  [LinkStatus.SUBMITTED_AND_VIEWED, LinkColors.TURQUOISE],
+  [LinkStatus.SUBMITTED_AND_VIEWED, LinkColors.TEAL],
   [LinkStatus.IN_PROGRESS, LinkColors.YELLOW],
   [LinkStatus.STORED, LinkColors.YELLOW],
   [LinkStatus.NOT_STARTED_YET, LinkColors.RED],

--- a/src/main/views/form/main/footer.njk
+++ b/src/main/views/form/main/footer.njk
@@ -1,66 +1,23 @@
-<footer class="govuk-footer govuk-footer--rebranded" role="contentinfo">
-  <div class="govuk-width-container">
-    <div class="govuk-footer__meta">
-      <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-        <ul class="govuk-footer__inline-list">
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="https://www.gov.uk/help">
-              {{ help }}
-            </a>
-          </li>
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="https://www.gov.uk/government/publications/hmcts-privacy-policy/hm-courts-and-tribunals-service-privacy-policy">
-              {{ privacy }}
-            </a>
-          </li>
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/cookies">
-              {{ cookiePolicy }}
-            </a>
-          </li>
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="/accessibility">
-              {{ accessibility }}
-            </a>
-          </li>
-           <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="https://www.gov.uk/guidance/employment-tribunal-offices-and-venues">
-              {{ contact }}
-            </a>
-          </li>
-           <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="https://www.gov.uk/help/terms-conditions">
-              {{ termsAndConditions }}
-            </a>
-          </li>
-           <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="https://www.gov.uk/cymraeg">
-              {{ wasanaethau }}
-            </a>
-          </li>
-           <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="https://www.gov.uk/government/organisations/government-digital-service">
-              {{ digitalService }}
-            </a>
-          </li>
-        </ul>
+{% from "govuk/components/footer/macro.njk" import govukFooter %}
 
-        <svg role="presentation" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
-            <path
-            fill="currentColor"
-            d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
-          />
-        </svg>
-        <span class="govuk-footer__licence-description">
-          {{ licence.p1 }}
-          <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">{{ licence.p2 }}</a>{{ licence.p3 }}
-        </span>
-      </div>
-      <div class="govuk-footer__meta-item">
-        <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">
-          {{ copyright }}
-        </a>
-      </div>
-    </div>
-  </div>
-</footer>
+{{ govukFooter({
+  containerClasses: "app-width-container",
+  meta: {
+    items: [
+      { text: help, href: "https://www.gov.uk/help" },
+      { text: privacy, href: "https://www.gov.uk/government/publications/hmcts-privacy-policy/hm-courts-and-tribunals-service-privacy-policy" },
+      { text: cookiePolicy, href: "/cookies" },
+      { text: accessibility, href: "/accessibility" },
+      { text: contact, href: "https://www.gov.uk/guidance/employment-tribunal-offices-and-venues" },
+      { text: termsAndConditions, href: "https://www.gov.uk/help/terms-conditions" },
+      { text: wasanaethau, href: "https://www.gov.uk/cymraeg" },
+      { text: digitalService, href: "https://www.gov.uk/government/organisations/government-digital-service" }
+    ]
+  },
+  contentLicence: {
+    html: licence.p1 + '<a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">' + licence.p2 + '</a>' + licence.p3
+  },
+  copyright: {
+    text: copyright
+  }
+}) }}

--- a/src/main/views/form/main/footer.njk
+++ b/src/main/views/form/main/footer.njk
@@ -15,7 +15,7 @@
     ]
   },
   contentLicence: {
-    html: licence.p1 + '<a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">' + licence.p2 + '</a>' + licence.p3
+    html: licence.p1 ~ '<a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">' ~ licence.p2 ~ '</a>' ~ licence.p3
   },
   copyright: {
     text: copyright

--- a/src/main/views/form/main/template.njk
+++ b/src/main/views/form/main/template.njk
@@ -1,18 +1,12 @@
 {% extends "govuk/template.njk" %}
 {% from "govuk/components/header/macro.njk" import govukHeader %}
+{% from "govuk/components/service-navigation/macro.njk" import govukServiceNavigation %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "../../components/timeout-modal.njk" import timeoutModal with context %}
 
 {% block head %}
   {% include "../../webpack/css.njk" %}
-  <link rel="icon" sizes="48x48" href="/assets/rebrand/images/favicon.ico">
-  <link rel="icon" sizes="any" href="/assets/rebrand/images/favicon.svg" type="image/svg+xml">
-  <link rel="mask-icon" href="/assets/rebrand/images/govuk-icon-mask.svg" color="#1d70b8">
-  <link rel="apple-touch-icon" href="/assets/rebrand/images/govuk-icon-180.png">
-  <link rel="manifest" href="/assets/rebrand/manifest.json">
-  <meta property="og:image" content="/assets/rebrand/images/govuk-opengraph-image.png">
-  <meta name="theme-color" content="#1d70b8">
   <script>
     window.dataLayer = window.dataLayer || [];
   </script>
@@ -43,38 +37,41 @@
   <!-- End of hidden session object for user already logged in check-->
 {% endblock %}
 
-{% set logInOrOut = {
-  href: "/logout",
-  text: signOut,
-  active: false
-}
-if isLoggedIn %}
+  {% set logInOrOut = {
+    href: "/logout",
+    text: signOut,
+    active: false
+  } if isLoggedIn %}
 
-{% block header %}
-  {% include "./cookie-banner.njk" %}
-  {{ govukHeader({
-    containerClasses: "govuk-width-container",
-    homepageUrl: "/",
-    productName: serviceName,
-    navigationClasses: 'govuk-header__navigation--end',
-    navigation: [logInOrOut],
-    rebrand: true
-  }) }}
-{% endblock %}
+  {% block headerStart %}
+    {% include "./cookie-banner.njk" %}
+  {% endblock %}
 
-{% block pageTitle %}
-  {{ title }}
-  -
-  {{ serviceName }}
-  -
-  {{ govUk }}
-{% endblock %}
+  {% block govukHeader %}
+    {{ govukHeader({
+      containerClasses: "govuk-width-container",
+      homepageUrl: "/",
+      productName: serviceName
+    }) }}
+  {% endblock %}
+
+  {% block govukServiceNavigation %}
+    {{ govukServiceNavigation({
+      navigationClasses: 'govuk-header__navigation--end',
+      navigation: [logInOrOut]
+    }) }}
+  {% endblock %}
+
+  {% block pageTitle %}
+    {{ title }} - {{ serviceName }} - {{ govUk }}
+  {% endblock %}
 
 {% block beforeContent %}
 
   {% set smartSurveyPageInfo = currentUrl | replace("/", "") %}
 
-  {% set phaseBarHtml = '<a class="govuk-link" rel="noreferrer noopener" href="' + phaseBanner.smartSurveyFeedbackUrl + smartSurveyPageInfo + '" target="_blank">' + phaseBanner.feedback + "</a> " + phaseBanner.additionalText %}
+  {# Use ~ for concatenation #}
+  {% set phaseBarHtml = '<a class="govuk-link" rel="noreferrer noopener" href="' ~ phaseBanner.smartSurveyFeedbackUrl ~ smartSurveyPageInfo ~ '" target="_blank">' ~ phaseBanner.feedback ~ "</a> " ~ phaseBanner.additionalText %}
 
 
   {% if welshEnabled == null or welshEnabled === 'undefined' or welshEnabled === true %}
@@ -103,21 +100,20 @@ if isLoggedIn %}
 
   {{ timeoutModal() }}
 
-  {{ govukPhaseBanner({
+    {{ govukPhaseBanner({
       tag: {
-          text: beta
+        text: beta
       },
-      html: phaseBarHtml,
-      rebrand: true
-  }) }}
-{% endblock %}
+      html: phaseBarHtml
+    }) }}
+  {% endblock %}
 
 {% block bodyEnd %}
   {# Run JavaScript at end of the <body>, to avoid blocking the initial render. #}
   {% include "../../webpack/js.njk" %}
 {% endblock %}
 
-{% block footer %}
+{% block footerStart %}
   {% if "/" !== currentUrl and "/?lng=en" != currentUrl and "/?lng=cy" != currentUrl and hideContactUs === undefined %}
     <div class="govuk-width-container">
       <details class="govuk-details" data-module="govuk-details">
@@ -138,6 +134,8 @@ if isLoggedIn %}
       </details>
     </div>
   {% endif %}
+{% endblock %}
 
+{% block govukFooter %}
   {% include "./footer.njk" %}
 {% endblock %}

--- a/src/main/views/form/main/template.njk
+++ b/src/main/views/form/main/template.njk
@@ -58,7 +58,7 @@
   {% block govukServiceNavigation %}
     {{ govukServiceNavigation({
       navigationClasses: 'govuk-header__navigation--end',
-      navigation: [logInOrOut]
+      navigation: [logInOrOut] if logInOrOut else []
     }) }}
   {% endblock %}
 

--- a/src/test/unit/helpers/controller/YourRequestAndApplicationsHelper.test.ts
+++ b/src/test/unit/helpers/controller/YourRequestAndApplicationsHelper.test.ts
@@ -127,7 +127,7 @@ describe('Your Request and Applications Helper', () => {
       expect(updatedApps[1].redirectUrl).toBe('/application-details/04a5064e-0766-4833-b740-d02520c604f2?lng=en');
       expect(updatedApps[1].linkValue).toBe('Amend my claim');
       expect(updatedApps[1].displayStatus).toBe('Viewed');
-      expect(updatedApps[1].statusColor).toBe('--turquoise');
+      expect(updatedApps[1].statusColor).toBe('--teal');
       expect(updatedApps[1].lastUpdatedDate).toEqual(new Date('2025-02-06'));
 
       expect(updatedApps[2].submitDate).toBe('3 February 2025');

--- a/src/test/unit/views/making-response-as-legal-representative.test.ts
+++ b/src/test/unit/views/making-response-as-legal-representative.test.ts
@@ -19,7 +19,7 @@ const PAGE_URL = '/making-response-as-legal-representative';
 const titleClass = 'govuk-heading-xl';
 const pClass = 'govuk-body';
 const expectedTitle = makingResponseAsLegalRepJson.title;
-const signOutLinkSelector = 'li.govuk-header__navigation-item a.govuk-header__link';
+const signOutLinkSelector = 'li.govuk-service-navigation__item a.govuk-service-navigation__link';
 
 let htmlRes: Document;
 describe('Making a response as a legal representative page', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8282,7 +8282,7 @@ __metadata:
     express-rate-limit: "npm:^7.0.0"
     express-session: "npm:^1.18.2"
     git-rev-sync: "npm:3.0.2"
-    govuk-frontend: "npm:^5.11.0"
+    govuk-frontend: "npm:^6.0.0"
     helmet: "npm:^8.0.0"
     html-webpack-plugin: "npm:^5.5.1"
     husky: "npm:^9.0.0"
@@ -9374,10 +9374,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"govuk-frontend@npm:^5.11.0":
-  version: 5.11.0
-  resolution: "govuk-frontend@npm:5.11.0"
-  checksum: 10/4d978e64847f2e05e6e6e9c530c3113a5591daeb46a9c77a3e6be2bcd4afcf62ddc85094a2f358a49d7cf8eb3dfe1a1793b42e701f96d366515d9053653cac8e
+"govuk-frontend@npm:^6.0.0":
+  version: 6.1.0
+  resolution: "govuk-frontend@npm:6.1.0"
+  checksum: 10/dfd478bd47c7726f633cb43ce755e3ed0a513fc783ab7ad53eece931531eefa7471aa00f7548505a4fe523c56bb0ba35092629a3c1eb3a03ad232b1af15cc811
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Updates govuk-frontend to v6 in the SYR frontend, mirroring the changes made in [et-sya-frontend#2348](https://github.com/hmcts/et-sya-frontend/pull/2348).

## Changes

- Replace raw footer HTML with `govukFooter` macro
- Add `govukServiceNavigation` import and block to template (navigation moved out of `govukHeader`)
- Remove deprecated `rebrand` option from `govukHeader` and `govukPhaseBanner`
- Remove favicon/rebrand links from `head` block (now handled by govuk-frontend v6 internally)
- Split `footer` block into `footerStart` and `govukFooter` blocks (v6 block names)
- Use `~` instead of `+` for Nunjucks string concatenation
- Replace `.govuk-header__navigation-item` with `.govuk-service-navigation__item` in SCSS
- Remove `.govuk-header__content` float rule (no longer needed)
- Rename `LinkColors.TURQUOISE` → `LinkColors.TEAL` (govuk-frontend v6 colour rename)
- Update test selectors and assertions for v6 changes

Co-Authored-By: Oz <oz-agent@warp.dev>