### PR TITLE
RET-6471: Add HMCTS Access login URL support via /o/authorize endpoint

### DIFF
--- a/charts/et-syr/Chart.yaml
+++ b/charts/et-syr/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: '1.0'
 description: A Helm chart for et-syr App
 name: et-syr
 home: https://github.com/hmcts/et-syr-frontend
-version: 1.0.6
+version: 1.0.7
 dependencies:
   - name: nodejs
     version: 3.2.0

--- a/charts/et-syr/values.yaml
+++ b/charts/et-syr/values.yaml
@@ -16,6 +16,8 @@ nodejs:
         - launch-darkly-sdk-key
   environment:
     IDAM_WEB_URL: 'https://idam-web-public.{{ .Values.global.environment }}.platform.hmcts.net/login'
+    IDAM_WEB_URL_HMCTS_ACCESS: 'https://idam-web-public.{{ .Values.global.environment }}.platform.hmcts.net/o/authorize'
+    HMCTS_ACCESS: 'false'
     IDAM_API_URL: 'https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net/o/token'
     REDIS_HOST: 'et-session-storage-{{ .Values.global.environment }}.redis.cache.windows.net'
     ET_SYA_API_HOST: 'http://et-sya-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal'

--- a/config/default.json
+++ b/config/default.json
@@ -23,6 +23,8 @@
     "idam": {
       "clientID": "et-syr",
       "authorizationURL": "https://idam-web-public.aat.platform.hmcts.net/login",
+      "hmctsAccessURL": "https://idam-web-public.aat.platform.hmcts.net/o/authorize",
+      "hmctsAccess": false,
       "clientSecret": "TO BE PICKED UP FROM ENV",
       "tokenURL": "https://idam-api.aat.platform.hmcts.net/o/token",
       "userInfoURL": "https://idam-api.aat.platform.hmcts.net/o/userinfo"

--- a/src/main/auth/index.ts
+++ b/src/main/auth/index.ts
@@ -15,7 +15,10 @@ export const getRedirectUrl = (
   languageParam: string
 ): string => {
   const clientID: string = process.env.IDAM_CLIENT_ID ?? config.get('services.idam.clientID');
-  const loginUrl: string = process.env.IDAM_WEB_URL ?? config.get('services.idam.authorizationURL');
+  const hmctsAccess: boolean = (process.env.HMCTS_ACCESS ?? String(config.get('services.idam.hmctsAccess'))) === 'true';
+  const loginUrl: string = hmctsAccess
+    ? process.env.IDAM_WEB_URL_HMCTS_ACCESS ?? config.get('services.idam.hmctsAccessURL')
+    : process.env.IDAM_WEB_URL ?? config.get('services.idam.authorizationURL');
   const callbackUrl = encodeURI(serviceUrl + callbackUrlPage);
   return `${loginUrl}?client_id=${clientID}&response_type=code&redirect_uri=${callbackUrl}&state=${guid}&ui_locales=${languageParam}`;
 };

--- a/src/test/unit/auth/auth.test.ts
+++ b/src/test/unit/auth/auth.test.ts
@@ -29,10 +29,15 @@ const AuthorisationTestConstants = {
 
 const loginUrl =
   process.env.IDAM_WEB_URL ?? config.get(AuthorisationTestConstants.AUTHORISATION_URL_CONFIGURATION_NAME);
+const hmctsAccessLoginUrl = process.env.IDAM_WEB_URL_HMCTS_ACCESS ?? config.get('services.idam.hmctsAccessURL');
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 describe('AuthorisationTest', () => {
   describe('getRedirectUrl', () => {
+    afterEach(() => {
+      delete process.env.HMCTS_ACCESS;
+    });
+
     test('should create a valid URL to redirect to the login screen', () => {
       expect(
         getRedirectUrl(
@@ -43,6 +48,20 @@ describe('AuthorisationTest', () => {
         )
       ).toBe(
         `${loginUrl}?client_id=et-syr&response_type=code&redirect_uri=http://localhost/oauth2/callback&state=${AuthorisationTestConstants.GUID}&ui_locales=${languages.ENGLISH}`
+      );
+    });
+
+    test('should use HMCTS Access authorize URL when HMCTS_ACCESS is true', () => {
+      process.env.HMCTS_ACCESS = 'true';
+      expect(
+        getRedirectUrl(
+          AuthorisationTestConstants.URL_LOCALHOST,
+          AuthUrls.CALLBACK,
+          AuthorisationTestConstants.GUID,
+          languages.ENGLISH
+        )
+      ).toBe(
+        `${hmctsAccessLoginUrl}?client_id=et-syr&response_type=code&redirect_uri=http://localhost/oauth2/callback&state=${AuthorisationTestConstants.GUID}&ui_locales=${languages.ENGLISH}`
       );
     });
   });


### PR DESCRIPTION
## RET-6471

https://tools.hmcts.net/jira/browse/RET-6471

## Changes

- Added `IDAM_WEB_URL_HMCTS_ACCESS` environment variable in the Helm chart (`values.yaml`) pointing to the `/o/authorize` endpoint
- Added `HMCTS_ACCESS` feature flag (default `false`) to the Helm chart and `config/default.json`
- Updated `src/main/auth/index.ts` to select the login URL based on `HMCTS_ACCESS` — when `true`, uses the new `/o/authorize` endpoint; when `false` (default), retains the existing `/login` endpoint
- Updated unit tests to cover both `HMCTS_ACCESS = false` and `HMCTS_ACCESS = true` paths