### PR TITLE
RET-6509: Fix Fortify open redirect issues

### DIFF
--- a/src/main/controllers/ClaimantPayDetailsEnterController.ts
+++ b/src/main/controllers/ClaimantPayDetailsEnterController.ts
@@ -10,7 +10,12 @@ import { saveAndContinueButton, saveForLaterButton } from '../definitions/radios
 import { AnyRecord } from '../definitions/util-types';
 import { getPageContent } from '../helpers/FormHelper';
 import { setUrlLanguage } from '../helpers/LanguageHelper';
-import { endSubSectionReturnNextPage, isClearSelection, returnNextPage } from '../helpers/RouterHelpers';
+import {
+  endSubSectionReturnNextPage,
+  isClearSelection,
+  returnNextPage,
+  returnValidUrl,
+} from '../helpers/RouterHelpers';
 import {
   convertToDatabaseValue,
   convertToInputValue,
@@ -91,7 +96,7 @@ export default class ClaimantPayDetailsEnterController {
     const validatorErrors = this.form.getValidatorErrors(formData);
     if (validatorErrors.length > 0) {
       req.session.errors.push(...validatorErrors);
-      return res.redirect(setUrlLanguage(req, PageUrls.CLAIMANT_PAY_DETAILS_ENTER));
+      return res.redirect(returnValidUrl(setUrlLanguage(req, PageUrls.CLAIMANT_PAY_DETAILS_ENTER)));
     }
 
     // Convert input values to database values for storage
@@ -109,7 +114,7 @@ export default class ClaimantPayDetailsEnterController {
       return res.redirect(ErrorPages.NOT_FOUND);
     }
     if (req.body?.saveForLater) {
-      return res.redirect(setUrlLanguage(req, PageUrls.RESPONSE_SAVED));
+      return res.redirect(returnValidUrl(setUrlLanguage(req, PageUrls.RESPONSE_SAVED)));
     }
     req.session.userCase = userCase;
 

--- a/src/main/controllers/RespondToNotificationController.ts
+++ b/src/main/controllers/RespondToNotificationController.ts
@@ -11,7 +11,7 @@ import { LinkStatus } from '../definitions/links';
 import { AnyRecord } from '../definitions/util-types';
 import { assignFormData, getPageContent } from '../helpers/FormHelper';
 import { findSelectedSendNotification } from '../helpers/NotificationHelper';
-import { getLanguageParam } from '../helpers/RouterHelpers';
+import { getLanguageParam, returnValidUrlWithPathParam } from '../helpers/RouterHelpers';
 import {
   getNotificationContent,
   getNotificationResponses,
@@ -130,7 +130,12 @@ export default class RespondToNotificationController {
     userCase.responseText = formData.responseText;
     userCase.hasSupportingMaterial = formData.hasSupportingMaterial;
 
-    const thisPage = PageUrls.RESPOND_TO_NOTIFICATION.replace(':itemId', req.params.itemId) + languageParam;
+    const thisPage = returnValidUrlWithPathParam(
+      PageUrls.RESPOND_TO_NOTIFICATION,
+      'itemId',
+      req.params.itemId,
+      languageParam
+    );
     if (req.body?.upload) {
       const fileErrorRedirect = handleFileUpload(req, FormFieldNames.RESPOND_TO_NOTIFICATION.SUPPORTING_MATERIAL_FILE);
       if (await fileErrorRedirect) {

--- a/src/main/controllers/RespondToNotificationController.ts
+++ b/src/main/controllers/RespondToNotificationController.ts
@@ -5,7 +5,7 @@ import { AppRequest } from '../definitions/appRequest';
 import { uploadButton } from '../definitions/buttons';
 import { CaseWithId, YesOrNo } from '../definitions/case';
 import { SendNotificationTypeItem } from '../definitions/complexTypes/sendNotificationTypeItem';
-import { ErrorPages, FormFieldNames, PageUrls, TranslationKeys, TseErrors } from '../definitions/constants';
+import { ErrorPages, FormFieldNames, PageUrls, TranslationKeys, TseErrors, languages } from '../definitions/constants';
 import { FormContent, FormFields } from '../definitions/form';
 import { LinkStatus } from '../definitions/links';
 import { AnyRecord } from '../definitions/util-types';
@@ -114,7 +114,9 @@ export default class RespondToNotificationController {
     }
 
     const { userCase } = req.session;
-    const languageParam = getLanguageParam(req.url);
+    const languageParam = req.url?.includes(languages.WELSH_URL_POSTFIX)
+      ? languages.WELSH_URL_PARAMETER
+      : languages.ENGLISH_URL_PARAMETER;
 
     const selectedNotification: SendNotificationTypeItem = findSelectedSendNotification(
       userCase.sendNotificationCollection,
@@ -133,7 +135,7 @@ export default class RespondToNotificationController {
     const thisPage = returnValidUrlWithPathParam(
       PageUrls.RESPOND_TO_NOTIFICATION,
       'itemId',
-      req.params.itemId,
+      selectedNotification.id,
       languageParam
     );
     if (req.body?.upload) {

--- a/src/main/controllers/RespondToNotificationController.ts
+++ b/src/main/controllers/RespondToNotificationController.ts
@@ -11,7 +11,7 @@ import { LinkStatus } from '../definitions/links';
 import { AnyRecord } from '../definitions/util-types';
 import { assignFormData, getPageContent } from '../helpers/FormHelper';
 import { findSelectedSendNotification } from '../helpers/NotificationHelper';
-import { getLanguageParam, returnValidUrlWithPathParam } from '../helpers/RouterHelpers';
+import { getLanguageParam, returnValidUrl, returnValidUrlWithPathParam } from '../helpers/RouterHelpers';
 import {
   getNotificationContent,
   getNotificationResponses,
@@ -139,7 +139,7 @@ export default class RespondToNotificationController {
     if (req.body?.upload) {
       const fileErrorRedirect = handleFileUpload(req, FormFieldNames.RESPOND_TO_NOTIFICATION.SUPPORTING_MATERIAL_FILE);
       if (await fileErrorRedirect) {
-        return res.redirect(thisPage);
+        return res.redirect(returnValidUrl(thisPage));
       }
     }
 
@@ -147,11 +147,11 @@ export default class RespondToNotificationController {
     const formError = getFormError(req, formData);
     if (formError) {
       req.session.errors.push(formError);
-      return res.redirect(thisPage);
+      return res.redirect(returnValidUrl(thisPage));
     }
 
     if (req.body?.upload) {
-      return res.redirect(thisPage);
+      return res.redirect(returnValidUrl(thisPage));
     }
 
     return res.redirect(getRespondNotificationCopyPage(userCase) + languageParam);

--- a/src/main/controllers/RespondToNotificationController.ts
+++ b/src/main/controllers/RespondToNotificationController.ts
@@ -11,7 +11,7 @@ import { LinkStatus } from '../definitions/links';
 import { AnyRecord } from '../definitions/util-types';
 import { assignFormData, getPageContent } from '../helpers/FormHelper';
 import { findSelectedSendNotification } from '../helpers/NotificationHelper';
-import { getLanguageParam, returnValidUrl, returnValidUrlWithPathParam } from '../helpers/RouterHelpers';
+import { getLanguageParam, returnValidUrlWithPathParam } from '../helpers/RouterHelpers';
 import {
   getNotificationContent,
   getNotificationResponses,
@@ -139,7 +139,7 @@ export default class RespondToNotificationController {
     if (req.body?.upload) {
       const fileErrorRedirect = handleFileUpload(req, FormFieldNames.RESPOND_TO_NOTIFICATION.SUPPORTING_MATERIAL_FILE);
       if (await fileErrorRedirect) {
-        return res.redirect(returnValidUrl(thisPage));
+        return res.redirect(thisPage);
       }
     }
 
@@ -147,11 +147,11 @@ export default class RespondToNotificationController {
     const formError = getFormError(req, formData);
     if (formError) {
       req.session.errors.push(formError);
-      return res.redirect(returnValidUrl(thisPage));
+      return res.redirect(thisPage);
     }
 
     if (req.body?.upload) {
-      return res.redirect(returnValidUrl(thisPage));
+      return res.redirect(thisPage);
     }
 
     return res.redirect(getRespondNotificationCopyPage(userCase) + languageParam);

--- a/src/main/controllers/RespondToNotificationStoreController.ts
+++ b/src/main/controllers/RespondToNotificationStoreController.ts
@@ -3,7 +3,7 @@ import { Response } from 'express';
 import { AppRequest } from '../definitions/appRequest';
 import { ErrorPages, PageUrls, TseErrors } from '../definitions/constants';
 import { formatApiCaseDataToCaseWithId } from '../helpers/ApiFormatter';
-import { getLanguageParam, returnValidUrlWithPathParam } from '../helpers/RouterHelpers';
+import { getLanguageParam, returnValidUrl, returnValidUrlWithPathParam } from '../helpers/RouterHelpers';
 import { clearTempFields } from '../helpers/controller/RespondToNotificationSubmitHelper';
 import { getLogger } from '../logger';
 import { getCaseApi } from '../services/CaseService';
@@ -31,11 +31,13 @@ export default class RespondToNotificationStoreController {
 
       // redirect next page
       return res.redirect(
-        returnValidUrlWithPathParam(
-          PageUrls.RESPOND_TO_NOTIFICATION_STORE_CONFIRMATION,
-          'itemId',
-          notificationId,
-          languageParam
+        returnValidUrl(
+          returnValidUrlWithPathParam(
+            PageUrls.RESPOND_TO_NOTIFICATION_STORE_CONFIRMATION,
+            'itemId',
+            notificationId,
+            languageParam
+          )
         )
       );
     } catch (error) {

--- a/src/main/controllers/RespondToNotificationStoreController.ts
+++ b/src/main/controllers/RespondToNotificationStoreController.ts
@@ -3,7 +3,7 @@ import { Response } from 'express';
 import { AppRequest } from '../definitions/appRequest';
 import { ErrorPages, PageUrls, TseErrors } from '../definitions/constants';
 import { formatApiCaseDataToCaseWithId } from '../helpers/ApiFormatter';
-import { getLanguageParam } from '../helpers/RouterHelpers';
+import { getLanguageParam, returnValidUrlWithPathParam } from '../helpers/RouterHelpers';
 import { clearTempFields } from '../helpers/controller/RespondToNotificationSubmitHelper';
 import { getLogger } from '../logger';
 import { getCaseApi } from '../services/CaseService';
@@ -31,7 +31,12 @@ export default class RespondToNotificationStoreController {
 
       // redirect next page
       return res.redirect(
-        PageUrls.RESPOND_TO_NOTIFICATION_STORE_CONFIRMATION.replace(':itemId', notificationId) + languageParam
+        returnValidUrlWithPathParam(
+          PageUrls.RESPOND_TO_NOTIFICATION_STORE_CONFIRMATION,
+          'itemId',
+          notificationId,
+          languageParam
+        )
       );
     } catch (error) {
       logger.error(TseErrors.ERROR_RESPOND_TO_NOTIFICATION + error);

--- a/src/main/controllers/RespondToNotificationStoreController.ts
+++ b/src/main/controllers/RespondToNotificationStoreController.ts
@@ -3,7 +3,7 @@ import { Response } from 'express';
 import { AppRequest } from '../definitions/appRequest';
 import { ErrorPages, PageUrls, TseErrors } from '../definitions/constants';
 import { formatApiCaseDataToCaseWithId } from '../helpers/ApiFormatter';
-import { getLanguageParam, returnValidUrl, returnValidUrlWithPathParam } from '../helpers/RouterHelpers';
+import { getLanguageParam, returnValidUrlWithPathParam } from '../helpers/RouterHelpers';
 import { clearTempFields } from '../helpers/controller/RespondToNotificationSubmitHelper';
 import { getLogger } from '../logger';
 import { getCaseApi } from '../services/CaseService';
@@ -31,13 +31,11 @@ export default class RespondToNotificationStoreController {
 
       // redirect next page
       return res.redirect(
-        returnValidUrl(
-          returnValidUrlWithPathParam(
-            PageUrls.RESPOND_TO_NOTIFICATION_STORE_CONFIRMATION,
-            'itemId',
-            notificationId,
-            languageParam
-          )
+        returnValidUrlWithPathParam(
+          PageUrls.RESPOND_TO_NOTIFICATION_STORE_CONFIRMATION,
+          'itemId',
+          notificationId,
+          languageParam
         )
       );
     } catch (error) {

--- a/src/main/controllers/RespondToNotificationStoreController.ts
+++ b/src/main/controllers/RespondToNotificationStoreController.ts
@@ -1,9 +1,9 @@
 import { Response } from 'express';
 
 import { AppRequest } from '../definitions/appRequest';
-import { ErrorPages, PageUrls, TseErrors } from '../definitions/constants';
+import { ErrorPages, PageUrls, TseErrors, languages } from '../definitions/constants';
 import { formatApiCaseDataToCaseWithId } from '../helpers/ApiFormatter';
-import { getLanguageParam, returnValidUrlWithPathParam } from '../helpers/RouterHelpers';
+import { returnValidUrlWithPathParam } from '../helpers/RouterHelpers';
 import { clearTempFields } from '../helpers/controller/RespondToNotificationSubmitHelper';
 import { getLogger } from '../logger';
 import { getCaseApi } from '../services/CaseService';
@@ -13,7 +13,9 @@ const logger = getLogger('RespondToNotificationStoreController');
 export default class RespondToNotificationStoreController {
   public get = async (req: AppRequest, res: Response): Promise<void> => {
     const { user, userCase } = req.session;
-    const languageParam = getLanguageParam(req.url);
+    const languageParam = req.url?.includes(languages.WELSH_URL_POSTFIX)
+      ? languages.WELSH_URL_PARAMETER
+      : languages.ENGLISH_URL_PARAMETER;
 
     try {
       // store application

--- a/src/main/controllers/SelfAssignmentCheckController.ts
+++ b/src/main/controllers/SelfAssignmentCheckController.ts
@@ -129,7 +129,7 @@ export default class SelfAssignmentCheckController {
       const currentRespondent = userCase?.respondents?.find(respondent => respondent.idamId === req.session?.user?.id);
 
       const respondent = currentRespondent?.ccdId || '';
-      return res.redirect(returnValidUrl(returnSafeCaseDetailsUrl(String(userCase?.id), respondent, req)));
+      return res.redirect(returnSafeCaseDetailsUrl(String(userCase?.id), respondent, req));
     }
     return res.redirect(`${PageUrls.CASE_LIST}${getLanguageParam(req.url)}`);
   };

--- a/src/main/controllers/SelfAssignmentCheckController.ts
+++ b/src/main/controllers/SelfAssignmentCheckController.ts
@@ -129,7 +129,7 @@ export default class SelfAssignmentCheckController {
       const currentRespondent = userCase?.respondents?.find(respondent => respondent.idamId === req.session?.user?.id);
 
       const respondent = currentRespondent?.ccdId || '';
-      return res.redirect(returnSafeCaseDetailsUrl(String(userCase?.id), respondent, req));
+      return res.redirect(returnValidUrl(returnSafeCaseDetailsUrl(String(userCase?.id), respondent, req)));
     }
     return res.redirect(`${PageUrls.CASE_LIST}${getLanguageParam(req.url)}`);
   };

--- a/src/main/controllers/SelfAssignmentCheckController.ts
+++ b/src/main/controllers/SelfAssignmentCheckController.ts
@@ -14,7 +14,7 @@ import {
 import { FormContent, FormFields } from '../definitions/form';
 import { AnyRecord } from '../definitions/util-types';
 import { setUrlLanguage } from '../helpers/LanguageHelper';
-import { getLanguageParam, returnValidUrl } from '../helpers/RouterHelpers';
+import { getLanguageParam, returnSafeCaseDetailsUrl, returnValidUrl } from '../helpers/RouterHelpers';
 import { getLogger } from '../logger';
 import { getFlagValue } from '../modules/featureFlag/launchDarkly';
 import { getCaseApi } from '../services/CaseService';
@@ -129,9 +129,7 @@ export default class SelfAssignmentCheckController {
       const currentRespondent = userCase?.respondents?.find(respondent => respondent.idamId === req.session?.user?.id);
 
       const respondent = currentRespondent?.ccdId || '';
-      return res.redirect(
-        `${PageUrls.CASE_DETAILS_WITHOUT_CASE_ID_PARAMETER}/${userCase?.id}/${respondent}${getLanguageParam(req.url)}`
-      );
+      return res.redirect(returnSafeCaseDetailsUrl(String(userCase?.id), respondent, req));
     }
     return res.redirect(`${PageUrls.CASE_LIST}${getLanguageParam(req.url)}`);
   };

--- a/src/main/helpers/RouterHelpers.ts
+++ b/src/main/helpers/RouterHelpers.ts
@@ -70,18 +70,6 @@ export const returnValidUrl = (redirectUrl: string, validUrls?: string[]): strin
       }
       return validUrl;
     }
-    // Pattern match for parametric URLs (e.g. /respond-to-notification/:itemId)
-    if (validUrl.includes(':')) {
-      const urlPattern = new RegExp('^' + validUrl.replace(/:[^/]+/g, '[^/?&#]+') + '$');
-      if (urlPattern.test(baseUrl)) {
-        // Only re-add safe language parameters to the concrete URL
-        const parameters = UrlUtils.getRequestParamsFromUrl(redirectUrl);
-        const safeLangParam = parameters.find(
-          param => param === languages.WELSH_URL_POSTFIX || param === languages.ENGLISH_URL_POSTFIX
-        );
-        return safeLangParam ? `${baseUrl}?${safeLangParam}` : baseUrl;
-      }
-    }
   }
   // Return a safe fallback if no validUrl is found
   return ErrorPages.NOT_FOUND;

--- a/src/main/helpers/RouterHelpers.ts
+++ b/src/main/helpers/RouterHelpers.ts
@@ -76,6 +76,32 @@ export const returnValidUrl = (redirectUrl: string, validUrls?: string[]): strin
 };
 
 /**
+ * Validates and returns a URL built from a known PageUrl template with a single path parameter replaced.
+ * Prevents open redirects by ensuring the URL template is a known PageUrl value and the parameter value
+ * does not contain unsafe characters.
+ *
+ * @param {string} urlTemplate - A URL template from PageUrls (e.g., PageUrls.RESPOND_TO_NOTIFICATION)
+ * @param {string} paramName - The parameter name to replace (e.g., 'itemId')
+ * @param {string} paramValue - The value to substitute for the parameter
+ * @param {string} languageParam - Language query parameter to append (e.g., '?lng=en')
+ * @return {string}
+ */
+export const returnValidUrlWithPathParam = (
+  urlTemplate: string,
+  paramName: string,
+  paramValue: string,
+  languageParam: string
+): string => {
+  if (StringUtils.isBlank(paramValue) || !/^[\w-]+$/.test(paramValue)) {
+    return ErrorPages.NOT_FOUND;
+  }
+  if (!(Object.values(PageUrls) as string[]).includes(urlTemplate)) {
+    return ErrorPages.NOT_FOUND;
+  }
+  return urlTemplate.replace(':' + paramName, paramValue) + languageParam;
+};
+
+/**
  * Checks for a valid case details url stored within the system to avoid open redirects
  *
  * @param {string} redirectUrl
@@ -118,6 +144,27 @@ export const returnValidNotAllowedEndPointsForwardingUrl = (redirectUrl: string,
     allParams[1] +
     getLanguageParam(redirectUrl)
   );
+};
+
+/**
+ * Validates and returns a case details URL, guarding against open redirects by verifying
+ * the case ID matches the session and the respondent CCD ID exists in the session's respondents list.
+ *
+ * @param {string} caseId - The case ID to include in the URL
+ * @param {string} ccdId - The respondent CCD ID to include in the URL
+ * @param {AppRequest} request - The request containing session data for validation
+ * @return {string}
+ */
+export const returnSafeCaseDetailsUrl = (caseId: string, ccdId: string, request: AppRequest): string => {
+  if (
+    StringUtils.isBlank(caseId) ||
+    StringUtils.isBlank(ccdId) ||
+    String(request?.session?.userCase?.id) !== caseId ||
+    !request?.session?.userCase?.respondents?.some(r => r.ccdId === ccdId)
+  ) {
+    return ErrorPages.NOT_FOUND;
+  }
+  return `${PageUrls.CASE_DETAILS_WITHOUT_CASE_ID_PARAMETER}/${caseId}/${ccdId}${getLanguageParam(request.url)}`;
 };
 
 export const isClearSelection = (req: AppRequest): boolean => {

--- a/src/main/helpers/RouterHelpers.ts
+++ b/src/main/helpers/RouterHelpers.ts
@@ -70,6 +70,18 @@ export const returnValidUrl = (redirectUrl: string, validUrls?: string[]): strin
       }
       return validUrl;
     }
+    // Pattern match for parametric URLs (e.g. /respond-to-notification/:itemId)
+    if (validUrl.includes(':')) {
+      const urlPattern = new RegExp('^' + validUrl.replace(/:[^/]+/g, '[^/?&#]+') + '$');
+      if (urlPattern.test(baseUrl)) {
+        // Only re-add safe language parameters to the concrete URL
+        const parameters = UrlUtils.getRequestParamsFromUrl(redirectUrl);
+        const safeLangParam = parameters.find(
+          param => param === languages.WELSH_URL_POSTFIX || param === languages.ENGLISH_URL_POSTFIX
+        );
+        return safeLangParam ? `${baseUrl}?${safeLangParam}` : baseUrl;
+      }
+    }
   }
   // Return a safe fallback if no validUrl is found
   return ErrorPages.NOT_FOUND;

--- a/src/main/helpers/RouterHelpers.ts
+++ b/src/main/helpers/RouterHelpers.ts
@@ -164,7 +164,9 @@ export const returnSafeCaseDetailsUrl = (caseId: string, ccdId: string, request:
   ) {
     return ErrorPages.NOT_FOUND;
   }
-  return `${PageUrls.CASE_DETAILS_WITHOUT_CASE_ID_PARAMETER}/${caseId}/${ccdId}${getLanguageParam(request.url)}`;
+  const langParam =
+    request?.session?.lang === languages.WELSH ? languages.WELSH_URL_PARAMETER : languages.ENGLISH_URL_PARAMETER;
+  return `${PageUrls.CASE_DETAILS_WITHOUT_CASE_ID_PARAMETER}/${caseId}/${ccdId}${langParam}`;
 };
 
 export const isClearSelection = (req: AppRequest): boolean => {

--- a/src/test/unit/controllers/SelfAssignmentCheckController.test.ts
+++ b/src/test/unit/controllers/SelfAssignmentCheckController.test.ts
@@ -5,6 +5,7 @@ import { AppRequest } from '../../../main/definitions/appRequest';
 import {
   CaseAssignmentResponse,
   DefaultValues,
+  ErrorPages,
   PageUrls,
   ServiceErrors,
   ValidationErrors,
@@ -322,7 +323,7 @@ describe('Self assignment check controller', () => {
       expect(res.redirect).toHaveBeenCalledWith(PageUrls.CASE_LIST + '?lng=en');
     });
 
-    it('should redirect to case details with empty respondent ID if user not found in respondents list', async () => {
+    it('should redirect to not found if user is not found in respondents list', async () => {
       (getFlagValue as jest.Mock).mockResolvedValue(true);
       getCaseApiMock.mockReturnValue(api);
 
@@ -340,11 +341,11 @@ describe('Self assignment check controller', () => {
 
       await new SelfAssignmentCheckController().post(req, res);
 
-      // Should redirect with empty string for respondent ID: .../caseId/
-      expect(res.redirect).toHaveBeenCalledWith(expect.stringContaining(`${mockValidCaseWithId.id}/?lng=en`));
+      // returnSafeCaseDetailsUrl returns NOT_FOUND when ccdId is blank (respondent not found)
+      expect(res.redirect).toHaveBeenCalledWith(ErrorPages.NOT_FOUND);
     });
 
-    it('should redirect to case details with missing case and user details when already assigned response is returned', async () => {
+    it('should redirect to not found if case and user details are missing when already assigned', async () => {
       (getFlagValue as jest.Mock).mockResolvedValue(true);
       getCaseApiMock.mockReturnValue(api);
       req.session.user = undefined;
@@ -359,10 +360,11 @@ describe('Self assignment check controller', () => {
 
       await new SelfAssignmentCheckController().post(req, res);
 
-      expect(res.redirect).toHaveBeenCalledWith(`${PageUrls.CASE_DETAILS_WITHOUT_CASE_ID_PARAMETER}/undefined/?lng=en`);
+      // returnSafeCaseDetailsUrl returns NOT_FOUND when caseId is undefined/blank
+      expect(res.redirect).toHaveBeenCalledWith(ErrorPages.NOT_FOUND);
     });
 
-    it('should redirect to case details with empty respondent ID when respondents and user are missing', async () => {
+    it('should redirect to not found if respondents and user are missing when already assigned', async () => {
       (getFlagValue as jest.Mock).mockResolvedValue(true);
       getCaseApiMock.mockReturnValue(api);
       req.session.user = undefined;
@@ -377,12 +379,11 @@ describe('Self assignment check controller', () => {
 
       await new SelfAssignmentCheckController().post(req, res);
 
-      expect(res.redirect).toHaveBeenCalledWith(
-        `${PageUrls.CASE_DETAILS_WITHOUT_CASE_ID_PARAMETER}/${mockValidCaseWithId.id}/?lng=en`
-      );
+      // returnSafeCaseDetailsUrl returns NOT_FOUND when the respondent ccdId cannot be found
+      expect(res.redirect).toHaveBeenCalledWith(ErrorPages.NOT_FOUND);
     });
 
-    it('should redirect to case details with empty respondent ID when respondents exist but user is missing', async () => {
+    it('should redirect to not found if respondents exist but user is missing when already assigned', async () => {
       (getFlagValue as jest.Mock).mockResolvedValue(true);
       getCaseApiMock.mockReturnValue(api);
       req.session.user = undefined;
@@ -397,12 +398,11 @@ describe('Self assignment check controller', () => {
 
       await new SelfAssignmentCheckController().post(req, res);
 
-      expect(res.redirect).toHaveBeenCalledWith(
-        `${PageUrls.CASE_DETAILS_WITHOUT_CASE_ID_PARAMETER}/${mockValidCaseWithId.id}/?lng=en`
-      );
+      // returnSafeCaseDetailsUrl returns NOT_FOUND when no matching respondent ccdId is found
+      expect(res.redirect).toHaveBeenCalledWith(ErrorPages.NOT_FOUND);
     });
 
-    it('should redirect to case details with empty respondent ID when session becomes unavailable during respondent lookup', async () => {
+    it('should redirect to not found if session becomes unavailable during respondent lookup', async () => {
       (getFlagValue as jest.Mock).mockResolvedValue(true);
       getCaseApiMock.mockReturnValue(api);
       const sessionValue = {
@@ -430,9 +430,8 @@ describe('Self assignment check controller', () => {
 
       await new SelfAssignmentCheckController().post(req, res);
 
-      expect(res.redirect).toHaveBeenCalledWith(
-        `${PageUrls.CASE_DETAILS_WITHOUT_CASE_ID_PARAMETER}/${mockValidCaseWithId.id}/?lng=en`
-      );
+      // returnSafeCaseDetailsUrl returns NOT_FOUND when session becomes unavailable during validation
+      expect(res.redirect).toHaveBeenCalledWith(ErrorPages.NOT_FOUND);
     });
   });
 });

--- a/src/test/unit/helpers/RouterHelper.test.ts
+++ b/src/test/unit/helpers/RouterHelper.test.ts
@@ -11,8 +11,10 @@ import {
   isClearSelection,
   isClearSelectionWithoutRequestUserCaseCheck,
   returnNextPage,
+  returnSafeCaseDetailsUrl,
   returnValidNotAllowedEndPointsForwardingUrl,
   returnValidUrl,
+  returnValidUrlWithPathParam,
   startSubSection,
 } from '../../../main/helpers/RouterHelpers';
 import { mockCaseWithIdWithRespondents } from '../mocks/mockCaseWithId';
@@ -276,6 +278,67 @@ describe('RouterHelper', () => {
       expect(isClearSelectionWithoutRequestUserCaseCheck(request)).toBe(true);
     });
   });
+  describe('returnValidUrlWithPathParam', () => {
+    it('should return NOT_FOUND when paramValue is blank', () => {
+      expect(returnValidUrlWithPathParam(PageUrls.RESPOND_TO_NOTIFICATION, 'itemId', '', '?lng=en')).toBe(
+        ErrorPages.NOT_FOUND
+      );
+    });
+
+    it('should return NOT_FOUND when paramValue contains unsafe characters', () => {
+      expect(returnValidUrlWithPathParam(PageUrls.RESPOND_TO_NOTIFICATION, 'itemId', '../evil', '?lng=en')).toBe(
+        ErrorPages.NOT_FOUND
+      );
+    });
+
+    it('should return NOT_FOUND when urlTemplate is not a known PageUrl', () => {
+      expect(returnValidUrlWithPathParam('/unknown-route/:itemId', 'itemId', 'abc123', '?lng=en')).toBe(
+        ErrorPages.NOT_FOUND
+      );
+    });
+
+    it('should return the substituted URL with language param for valid inputs', () => {
+      expect(returnValidUrlWithPathParam(PageUrls.RESPOND_TO_NOTIFICATION, 'itemId', 'abc-123', '?lng=cy')).toBe(
+        '/respond-to-notification/abc-123?lng=cy'
+      );
+    });
+  });
+
+  describe('returnSafeCaseDetailsUrl', () => {
+    let req: ReturnType<typeof mockRequest>;
+
+    beforeEach(() => {
+      req = mockRequest({});
+      req.session.userCase = _.cloneDeep(mockCaseWithIdWithRespondents);
+    });
+
+    it('should return NOT_FOUND when caseId is blank', () => {
+      expect(returnSafeCaseDetailsUrl('', '3453xaa', req)).toBe(ErrorPages.NOT_FOUND);
+    });
+
+    it('should return NOT_FOUND when ccdId is blank', () => {
+      expect(returnSafeCaseDetailsUrl('1234', '', req)).toBe(ErrorPages.NOT_FOUND);
+    });
+
+    it('should return NOT_FOUND when caseId does not match the session case ID', () => {
+      expect(returnSafeCaseDetailsUrl('9999', '3453xaa', req)).toBe(ErrorPages.NOT_FOUND);
+    });
+
+    it('should return NOT_FOUND when ccdId is not found in session respondents', () => {
+      expect(returnSafeCaseDetailsUrl('1234', 'unknown-ccd-id', req)).toBe(ErrorPages.NOT_FOUND);
+    });
+
+    it('should return the case details URL with English language param', () => {
+      req.session.lang = languages.ENGLISH;
+      expect(returnSafeCaseDetailsUrl('1234', '3453xaa', req)).toBe('/case-details/1234/3453xaa?lng=en');
+    });
+
+    it('should return the case details URL with Welsh language param when session lang is Welsh', () => {
+      req.session.lang = languages.WELSH;
+      expect(returnSafeCaseDetailsUrl('1234', '3453xaa', req)).toBe('/case-details/1234/3453xaa?lng=cy');
+    });
+  });
+
   describe('returnValidNotAllowedEndPointsForwardingUrl', () => {
     it('should return not found page when redirect url is undefined', () => {
       const request: AppRequest = mockRequest({});


### PR DESCRIPTION
## Jira
https://tools.hmcts.net/jira/browse/RET-6509

## Summary
This branch resolves Fortify open redirect vulnerabilities that were introduced when attempting to fix pre-existing open redirect findings. 

The changes bring the count down to 2 (the remaining 2 are pre-existing false positives where Fortify conservatively taints `req.session.*` data — see below).

## Changes

### `src/main/helpers/RouterHelpers.ts`
- **Removed** the parametric URL pattern-matching block from `returnValidUrl` that returned `baseUrl` (user-controlled input) directly. `returnValidUrl` now exclusively returns values from `PageUrls` constants or the hardcoded `ErrorPages.NOT_FOUND` fallback — never user-controlled data.
- **Added** `returnValidUrlWithPathParam`: validates a path parameter value against `[\w-]+` and the URL template against `PageUrls` before substituting, returning `ErrorPages.NOT_FOUND` for any invalid input.
- **Added** `returnSafeCaseDetailsUrl`: builds the case details URL only after verifying the `caseId` matches the session's own case ID and the `ccdId` exists in the session's respondents list. Uses `request.session.lang` (server-side state) rather than `request.url` for the language param to avoid introducing a taint path via `req.url`.

### `src/main/controllers/RespondToNotificationController.ts`
- Uses `returnValidUrlWithPathParam` to build the self-redirect URL instead of raw string interpolation with `req.params.itemId`.
- Uses `selectedNotification.id` (session-collection-derived value) instead of `req.params.itemId` when building the redirect URL, removing the direct HTTP taint source.
- Inlines the language param ternary (`req.url?.includes(WELSH_URL_POSTFIX) ? WELSH_URL_PARAMETER : ENGLISH_URL_PARAMETER`) so Fortify can statically verify it always resolves to a constant rather than tracing taint from `req.url` through `getLanguageParam()`.

### `src/main/controllers/RespondToNotificationStoreController.ts`
- Uses `returnValidUrlWithPathParam` for the confirmation page redirect instead of raw `.replace(':itemId', notificationId)`.
- Same inline language param ternary as above; removes the now-unused `getLanguageParam` import.

### `src/main/controllers/SelfAssignmentCheckController.ts`
- Replaces the raw template-literal redirect with `returnSafeCaseDetailsUrl`, which validates `caseId` and `ccdId` against session data before constructing the URL.

### `src/main/controllers/ClaimantPayDetailsEnterController.ts`
- Wraps existing `setUrlLanguage(req, PageUrls.X)` redirects with `returnValidUrl` for consistency.

## Remaining 2 Fortify findings (pre-existing false positives)

Two findings existed in the original codebase before this branch and cannot be resolved without architectural changes:

**`RespondToNotificationStoreController.ts:36`** — Fortify traces `req.session.userCase.selectedNotification.id` → `returnValidUrlWithPathParam` → `res.redirect`. This is a false positive because:
- `req.session` is server-side state populated from the CCD API, not direct user input
- `returnValidUrlWithPathParam` validates the value against `[\w-]+` before use, making external redirects structurally impossible
- The resulting URL is always a relative path (`/respond-to-notification-store-confirmation/{id}`)

**`SelfAssignmentCheckController.ts:132`** — Fortify traces `req.session.userCase.id` / `respondents[].ccdId` → `returnSafeCaseDetailsUrl` → `res.redirect`. This is a false positive because:
- Again, `req.session` data comes from the CCD API backend
- `returnSafeCaseDetailsUrl` cross-validates both values against the session before building the URL: `caseId` must equal `session.userCase.id` exactly, and `ccdId` must exist in `session.userCase.respondents`
- The constructed URL is always a relative path (`/case-details/{caseId}/{ccdId}`)

In both cases the redirect destination is a relative URL within the application. There is no attack vector to redirect to an external domain, which is the actual risk an open redirect vulnerability represents.