### PR TITLE
HMCTS-Access-Scopes: add scope parameter to IDAM redirect URL

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -4,6 +4,7 @@
     "idam": {
       "clientID": "et-syr",
       "authorizationURL": "http://localhost:5062/login",
+      "hmctsAccessURL": "http://localhost:5062/o/authorize",
       "clientSecret": "test1234",
       "tokenURL": "http://localhost:5062/o/token",
       "userInfoURL": "http://localhost:5062/o/userinfo"

--- a/src/main/auth/index.ts
+++ b/src/main/auth/index.ts
@@ -20,7 +20,9 @@ export const getRedirectUrl = (
     ? process.env.IDAM_WEB_URL_HMCTS_ACCESS ?? config.get('services.idam.hmctsAccessURL')
     : process.env.IDAM_WEB_URL ?? config.get('services.idam.authorizationURL');
   const callbackUrl = encodeURI(serviceUrl + callbackUrlPage);
-  return `${loginUrl}?client_id=${clientID}&response_type=code&redirect_uri=${callbackUrl}&state=${guid}&ui_locales=${languageParam}`;
+  return `${loginUrl}?client_id=${clientID}&response_type=code&redirect_uri=${callbackUrl}&state=${guid}&ui_locales=${languageParam}&scope=${encodeURIComponent(
+    'openid profile roles'
+  )}`;
 };
 
 export const getUserDetails = async (

--- a/src/test/unit/auth/auth.test.ts
+++ b/src/test/unit/auth/auth.test.ts
@@ -47,7 +47,7 @@ describe('AuthorisationTest', () => {
           languages.ENGLISH
         )
       ).toBe(
-        `${loginUrl}?client_id=et-syr&response_type=code&redirect_uri=http://localhost/oauth2/callback&state=${AuthorisationTestConstants.GUID}&ui_locales=${languages.ENGLISH}`
+        `${loginUrl}?client_id=et-syr&response_type=code&redirect_uri=http://localhost/oauth2/callback&state=${AuthorisationTestConstants.GUID}&ui_locales=${languages.ENGLISH}&scope=openid%20profile%20roles`
       );
     });
 
@@ -61,7 +61,7 @@ describe('AuthorisationTest', () => {
           languages.ENGLISH
         )
       ).toBe(
-        `${hmctsAccessLoginUrl}?client_id=et-syr&response_type=code&redirect_uri=http://localhost/oauth2/callback&state=${AuthorisationTestConstants.GUID}&ui_locales=${languages.ENGLISH}`
+        `${hmctsAccessLoginUrl}?client_id=et-syr&response_type=code&redirect_uri=http://localhost/oauth2/callback&state=${AuthorisationTestConstants.GUID}&ui_locales=${languages.ENGLISH}&scope=openid%20profile%20roles`
       );
     });
   });


### PR DESCRIPTION
## Summary

Adds `openid profile roles` scope to the IDAM authorization redirect URL and updates the auth tests to match.

### Changes
- `src/main/auth/index.ts` — appends `&scope=openid%20profile%20roles` to the login redirect URL
- `config/development.json` — related config update
- `src/test/unit/auth/auth.test.ts` — updated expected URLs to include the scope parameter