### PR TITLE
RET-6560: Add IDAM end session URL for proper logout flow

### DIFF
--- a/charts/et-syr/Chart.yaml
+++ b/charts/et-syr/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: '1.0'
 description: A Helm chart for et-syr App
 name: et-syr
 home: https://github.com/hmcts/et-syr-frontend
-version: 1.0.8
+version: 1.0.9
 dependencies:
   - name: nodejs
     version: 3.2.0

--- a/charts/et-syr/values.yaml
+++ b/charts/et-syr/values.yaml
@@ -17,6 +17,7 @@ nodejs:
   environment:
     IDAM_WEB_URL: 'https://idam-web-public.{{ .Values.global.environment }}.platform.hmcts.net/login'
     IDAM_WEB_URL_HMCTS_ACCESS: 'https://idam-web-public.{{ .Values.global.environment }}.platform.hmcts.net/o/authorize'
+    IDAM_END_SESSION_URL: 'https://idam-web-public.{{ .Values.global.environment }}.platform.hmcts.net/o/endSession'
     HMCTS_ACCESS: 'false'
     IDAM_API_URL: 'https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net/o/token'
     REDIS_HOST: 'et-session-storage-{{ .Values.global.environment }}.redis.cache.windows.net'

--- a/config/default.json
+++ b/config/default.json
@@ -24,6 +24,7 @@
       "clientID": "et-syr",
       "authorizationURL": "https://idam-web-public.aat.platform.hmcts.net/login",
       "hmctsAccessURL": "https://idam-web-public.aat.platform.hmcts.net/o/authorize",
+      "endSessionURL": "https://idam-web-public.aat.platform.hmcts.net/o/endSession",
       "hmctsAccess": false,
       "clientSecret": "TO BE PICKED UP FROM ENV",
       "tokenURL": "https://idam-api.aat.platform.hmcts.net/o/token",

--- a/config/development.json
+++ b/config/development.json
@@ -7,7 +7,8 @@
       "hmctsAccessURL": "http://localhost:5062/o/authorize",
       "clientSecret": "test1234",
       "tokenURL": "http://localhost:5062/o/token",
-      "userInfoURL": "http://localhost:5062/o/userinfo"
+      "userInfoURL": "http://localhost:5062/o/userinfo",
+      "endSessionURL": "http://localhost:5062/o/endSession"
     },
     "addressLookup": {
       "url": "https://api.os.uk/search/places/v1/postcode",

--- a/src/main/modules/oidc/index.ts
+++ b/src/main/modules/oidc/index.ts
@@ -27,7 +27,7 @@ export class Oidc {
   public enableFor(app: Application): void {
     const port = app.locals.developmentMode ? `:${config.get('port')}` : '';
     const serviceUrl = (res: Response): string => `${HTTPS_PROTOCOL}${res.locals.host}${port}`;
-    const idamSignOutUrl: string = config.get('services.idam.endSessionURL');
+    const idamSignOutUrl: string = process.env.IDAM_END_SESSION_URL ?? config.get('services.idam.endSessionURL');
 
     app.get(
       PageUrls.CASE_DETAILS_WITH_CASE_ID_RESPONDENT_CCD_ID_PARAMETERS,

--- a/src/main/modules/oidc/index.ts
+++ b/src/main/modules/oidc/index.ts
@@ -27,6 +27,7 @@ export class Oidc {
   public enableFor(app: Application): void {
     const port = app.locals.developmentMode ? `:${config.get('port')}` : '';
     const serviceUrl = (res: Response): string => `${HTTPS_PROTOCOL}${res.locals.host}${port}`;
+    const idamSignOutUrl: string = config.get('services.idam.endSessionURL');
 
     app.get(
       PageUrls.CASE_DETAILS_WITH_CASE_ID_RESPONDENT_CCD_ID_PARAMETERS,
@@ -71,11 +72,18 @@ export class Oidc {
     });
 
     app.get(AuthUrls.LOGOUT, (req: AppRequest, res: Response) => {
+      // serviceUrl(res) resolves to the homepage of the service and is used as the post_logout_redirect_uri for IDAM,
+      // so that after logout, user is redirected to the homepage
+      const params = new URLSearchParams({
+        id_token_hint: req.session.user?.accessToken,
+        post_logout_redirect_uri: serviceUrl(res),
+      });
+
       req.session.destroy(err => {
         if (err) {
           logger.error(SessionErrors.ERROR_DESTROYING_SESSION);
         }
-        return res.redirect(PageUrls.HOME);
+        res.redirect(idamSignOutUrl + '?' + params.toString());
       });
     });
 

--- a/src/test/unit/modules/oidc/oidc.test.ts
+++ b/src/test/unit/modules/oidc/oidc.test.ts
@@ -1,0 +1,153 @@
+import config from 'config';
+import { Application, Response } from 'express';
+
+import { AppRequest } from '../../../../main/definitions/appRequest';
+import { AuthUrls, HTTPS_PROTOCOL, PageUrls, SessionErrors } from '../../../../main/definitions/constants';
+import { Oidc } from '../../../../main/modules/oidc';
+
+jest.mock('@hmcts/nodejs-logging', () => {
+  const mockError = jest.fn();
+  return {
+    __mockError: mockError,
+    Logger: {
+      getLogger: () => ({
+        error: mockError,
+        info: jest.fn(),
+        warn: jest.fn(),
+      }),
+    },
+  };
+});
+
+const { __mockError: mockLoggerError } = jest.requireMock('@hmcts/nodejs-logging') as {
+  __mockError: jest.Mock;
+};
+
+const idamSignOutUrl: string = config.get('services.idam.endSessionURL');
+
+describe('Oidc logout handler', () => {
+  let logoutHandler: (req: AppRequest, res: Response) => void;
+  const mockHost = 'localhost:3003';
+
+  beforeAll(() => {
+    const handlers = new Map<string, (req: AppRequest, res: Response) => void>();
+    const mockApp = {
+      locals: { developmentMode: false },
+      get: (path: string, handler: (req: AppRequest, res: Response) => void) => handlers.set(path, handler),
+      use: jest.fn(),
+    } as unknown as Application;
+
+    new Oidc().enableFor(mockApp);
+    logoutHandler = handlers.get(AuthUrls.LOGOUT);
+  });
+
+  let mockRes: Partial<Response>;
+
+  beforeEach(() => {
+    mockLoggerError.mockClear();
+    mockRes = {
+      redirect: jest.fn(),
+      locals: { host: mockHost },
+    } as unknown as Partial<Response>;
+  });
+
+  test('destroys the session on logout', () => {
+    const mockDestroy = jest.fn(cb => cb(null));
+    const mockReq = {
+      session: { user: { accessToken: 'testToken' }, destroy: mockDestroy },
+    } as unknown as AppRequest;
+
+    logoutHandler(mockReq, mockRes as Response);
+
+    expect(mockDestroy).toHaveBeenCalledTimes(1);
+  });
+
+  test('redirects to IDAM end session URL with id_token_hint and post_logout_redirect_uri', () => {
+    const accessToken = 'testAccessToken';
+    const mockReq = {
+      session: {
+        user: { accessToken },
+        destroy: jest.fn(cb => cb(null)),
+      },
+    } as unknown as AppRequest;
+
+    logoutHandler(mockReq, mockRes as Response);
+
+    const expectedParams = new URLSearchParams({
+      id_token_hint: accessToken,
+      post_logout_redirect_uri: `${HTTPS_PROTOCOL}${mockHost}`,
+    });
+    expect(mockRes.redirect).toHaveBeenCalledWith(`${idamSignOutUrl}?${expectedParams.toString()}`);
+  });
+
+  test('does not redirect to home page on logout', () => {
+    const mockReq = {
+      session: {
+        user: { accessToken: 'testToken' },
+        destroy: jest.fn(cb => cb(null)),
+      },
+    } as unknown as AppRequest;
+
+    logoutHandler(mockReq, mockRes as Response);
+
+    expect(mockRes.redirect).not.toHaveBeenCalledWith(PageUrls.HOME);
+  });
+
+  test('still redirects to IDAM end session URL when session destroy errors', () => {
+    const accessToken = 'testAccessToken';
+    const mockReq = {
+      session: {
+        user: { accessToken },
+        destroy: jest.fn(cb => cb(new Error('session destroy error'))),
+      },
+    } as unknown as AppRequest;
+
+    logoutHandler(mockReq, mockRes as Response);
+
+    expect(mockRes.redirect).toHaveBeenCalled();
+    const redirectUrl = (mockRes.redirect as jest.Mock).mock.calls[0][0] as string;
+    expect(redirectUrl.startsWith(idamSignOutUrl)).toBe(true);
+  });
+
+  test('logs an error when session destroy fails', () => {
+    const mockReq = {
+      session: {
+        user: { accessToken: 'testToken' },
+        destroy: jest.fn(cb => cb(new Error('session destroy error'))),
+      },
+    } as unknown as AppRequest;
+
+    logoutHandler(mockReq, mockRes as Response);
+
+    expect(mockLoggerError).toHaveBeenCalledWith(SessionErrors.ERROR_DESTROYING_SESSION);
+  });
+
+  test('does not log an error when session destroy succeeds', () => {
+    const mockReq = {
+      session: {
+        user: { accessToken: 'testToken' },
+        destroy: jest.fn(cb => cb(null)),
+      },
+    } as unknown as AppRequest;
+
+    logoutHandler(mockReq, mockRes as Response);
+
+    expect(mockLoggerError).not.toHaveBeenCalled();
+  });
+
+  test('still redirects to IDAM end session URL when no user is in the session', () => {
+    const mockReq = {
+      session: {
+        user: undefined,
+        destroy: jest.fn(cb => cb(null)),
+      },
+    } as unknown as AppRequest;
+
+    logoutHandler(mockReq, mockRes as Response);
+
+    expect(mockRes.redirect).toHaveBeenCalled();
+    const redirectUrl = (mockRes.redirect as jest.Mock).mock.calls[0][0] as string;
+    expect(redirectUrl).toContain(idamSignOutUrl);
+    expect(redirectUrl).toContain(`post_logout_redirect_uri=${encodeURIComponent(`${HTTPS_PROTOCOL}${mockHost}`)}`);
+  });
+});


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RET-6560

## Summary

Updates the OIDC logout handler to perform a proper IDAM end-session redirect rather than redirecting back to the home page.

## Changes

### `src/main/modules/oidc/index.ts`
- Reads `services.idam.endSessionURL` from config on module initialisation
- On `GET /logout`, builds a `URLSearchParams` object containing:
  - `id_token_hint` — the user's IDAM access token (from `req.session.user?.accessToken`)
  - `post_logout_redirect_uri` — the service base URL
- Destroys the session and redirects to the IDAM end-session URL with those params appended, replacing the previous redirect to `PageUrls.HOME`

### `config/default.json` / `config/development.json`
- Added `services.idam.endSessionURL` config entry

### `charts/et-syr/values.yaml` / `charts/et-syr/Chart.yaml`
- Chart updates to support the new config value in deployed environments

### `src/test/unit/modules/oidc/oidc.test.ts` *(new file)*
- Unit tests covering the logout handler:
  - Session is destroyed on logout
  - Redirects to the IDAM end-session URL with correct `id_token_hint` and `post_logout_redirect_uri` query params
  - Does **not** redirect to `PageUrls.HOME`
  - Still redirects to IDAM end-session URL when `session.destroy` errors
  - Logs error via logger when session destroy fails; does not log when it succeeds
  - Handles missing `req.session.user` gracefully via optional chaining