### PR TITLE
feat: add ManifestController and manifest.json for PWA support

### DIFF
--- a/src/main/assets/manifest.json
+++ b/src/main/assets/manifest.json
@@ -1,0 +1,42 @@
+{
+  "name": "et syr frontend",
+  "short_name": "et syr",
+  "start_url": "/",
+  "icons": [
+    {
+      "src": "images/favicon.ico",
+      "type": "image/x-icon",
+      "sizes": "48x48"
+    },
+    {
+      "src": "images/favicon.svg",
+      "type": "image/svg+xml",
+      "sizes": "150x150",
+      "purpose": "any"
+    },
+    {
+      "src": "images/govuk-icon-180.png",
+      "type": "image/png",
+      "sizes": "180x180",
+      "purpose": "maskable"
+    },
+    {
+      "src": "images/govuk-icon-192.png",
+      "type": "image/png",
+      "sizes": "192x192",
+      "purpose": "maskable"
+    },
+    {
+      "src": "images/govuk-icon-512.png",
+      "type": "image/png",
+      "sizes": "512x512",
+      "purpose": "maskable"
+    },
+    {
+      "src": "images/govuk-icon-mask.svg",
+      "type": "image/svg+xml",
+      "sizes": "150x150",
+      "purpose": "monochrome"
+    }
+  ]
+}

--- a/src/main/controllers/ManifestController.ts
+++ b/src/main/controllers/ManifestController.ts
@@ -1,0 +1,10 @@
+import * as path from 'path';
+
+import { Request, Response } from 'express';
+
+export default class ManifestController {
+  public get(req: Request, res: Response): void {
+    res.setHeader('Content-Type', 'application/manifest+json');
+    res.sendFile(path.join(__dirname, '../assets/manifest.json'));
+  }
+}

--- a/src/main/definitions/constants.ts
+++ b/src/main/definitions/constants.ts
@@ -112,6 +112,7 @@ export const PageUrls = {
   SELF_ASSIGNMENT_CHECK: '/self-assignment-check',
   CASE_LIST: '/case-list',
   DOCUMENTS: '/documents',
+  MANIFEST_URL: '/assets/manifest.json',
   YOUR_RESPONSE_FORM: '/your-response-form',
   CASE_DETAILS_WITH_CASE_ID_RESPONDENT_CCD_ID_PARAMETERS: '/case-details/:caseSubmissionReference/:ccdId',
   CASE_DETAILS_WITHOUT_CASE_ID_PARAMETER: '/case-details',

--- a/src/main/modules/oidc/noSignInRequiredEndpoints.ts
+++ b/src/main/modules/oidc/noSignInRequiredEndpoints.ts
@@ -6,6 +6,7 @@ export const noSignInRequiredEndpoints: string[] = [
   PageUrls.CASE_NUMBER_CHECK,
   PageUrls.RETURN_TO_EXISTING_RESPONSE,
   PageUrls.MAKING_RESPONSE_AS_LEGAL_REPRESENTATIVE,
+  PageUrls.MANIFEST_URL,
 ];
 
 export const validateNoSignInEndpoints = (url: string): boolean => {

--- a/src/main/modules/routes/routes.ts
+++ b/src/main/modules/routes/routes.ts
@@ -57,6 +57,7 @@ import HoldingPageController from '../../controllers/HoldingPageController';
 import HomeController from '../../controllers/HomeController';
 import IsClaimantEmploymentWithRespondentContinuingController from '../../controllers/IsClaimantEmploymentWithRespondentContinuingController';
 import MakingResponseAsLegalRepController from '../../controllers/MakingResponseAsLegalRepController';
+import ManifestController from '../../controllers/ManifestController';
 import NewSelfAssignmentRequestController from '../../controllers/NewSelfAssignmentRequestController';
 import NotificationController from '../../controllers/NotificationController';
 import NotificationDetailsController from '../../controllers/NotificationDetailsController';
@@ -145,6 +146,7 @@ export class Routes {
     app.get(PageUrls.CHECKLIST, new ChecklistController().get);
     app.get(PageUrls.CASE_LIST_CHECK, new CaseListCheckController().get);
     app.get(PageUrls.YOUR_RESPONSE_FORM, new YourResponseFormController().get);
+    app.get(PageUrls.MANIFEST_URL, new ManifestController().get);
     app.get(PageUrls.SELF_ASSIGNMENT_FORM, new SelfAssignmentFormController().get);
     app.post(PageUrls.SELF_ASSIGNMENT_FORM, new SelfAssignmentFormController().post);
     app.get(PageUrls.SELF_ASSIGNMENT_CHECK, new SelfAssignmentCheckController().get);

--- a/src/test/unit/controllers/ManifestController.test.ts
+++ b/src/test/unit/controllers/ManifestController.test.ts
@@ -1,0 +1,18 @@
+import ManifestController from '../../../main/controllers/ManifestController';
+import { mockRequest } from '../mocks/mockRequest';
+import { mockResponse } from '../mocks/mockResponse';
+
+const manifestController = new ManifestController();
+
+describe('Manifest controller', () => {
+  it('should set the manifest content type and send the manifest file', () => {
+    const response = mockResponse();
+    (response as any).sendFile = jest.fn();
+    const request = mockRequest({});
+
+    manifestController.get(request, response);
+
+    expect(response.setHeader).toHaveBeenCalledWith('Content-Type', 'application/manifest+json');
+    expect((response as any).sendFile).toHaveBeenCalledWith(expect.stringContaining('assets/manifest.json'));
+  });
+});


### PR DESCRIPTION
## Jira

https://tools.hmcts.net/jira/browse/RET-6635

## Problem

Modern browsers (Chrome, Edge, etc.) automatically request a [Web App Manifest](https://developer.mozilla.org/en-US/docs/Web/Manifest) from sites to check for PWA (Progressive Web App) support. As the et-sya service did not have this file, the requests were constantly either throwing a 302 redirect to the IDAM login page or when a user was logged in, a 404 which was causing a spike in AppInsights failures

## Solution

- Added `src/main/assets/manifest.json` - a standard web app manifest referencing the existing GOV.UK Frontend icons (favicon, apple-touch-icon, maskable icons).
- Created `ManifestController` which serves the manifest file with the correct `application/manifest+json` content type using `res.sendFile`.
- Registered `GET /assets/manifest.json` in `routes.ts` using the existing `PageUrls.MANIFEST_URL` constant.

## Changes

- `src/main/assets/manifest.json` - new manifest file
- `src/main/controllers/ManifestController.ts` - new controller
- `src/main/modules/routes/routes.ts` - route registered for `PageUrls.MANIFEST_URL`
- `src/test/unit/controller/ManifestController.test.ts` - unit test