### PR TITLE
chore: update Helm chart version to 1.0.11 and adjust API host config

### DIFF
--- a/charts/et-syr/Chart.yaml
+++ b/charts/et-syr/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: '1.0'
 description: A Helm chart for et-syr App
 name: et-syr
 home: https://github.com/hmcts/et-syr-frontend
-version: 1.0.10
+version: 1.0.11
 dependencies:
   - name: nodejs
     version: 3.2.1

--- a/charts/et-syr/values.yaml
+++ b/charts/et-syr/values.yaml
@@ -21,7 +21,7 @@ nodejs:
     HMCTS_ACCESS: 'false'
     IDAM_API_URL: 'https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net/o/token'
     REDIS_HOST: 'et-session-storage-{{ .Values.global.environment }}.redis.cache.windows.net'
-    ET_SYA_API_HOST: 'http://et-sya-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal'
+    ET_SYA_API_HOST: 'http://et-cos-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal'
     PCQ_URL: 'https://pcq.{{ .Values.global.environment }}.platform.hmcts.net/service-endpoint'
     PCQ_HEALTH_URL: 'https://pcq.{{ .Values.global.environment }}.platform.hmcts.net/health'
     PCQ_ENABLED: 'true'

--- a/config/development.json
+++ b/config/development.json
@@ -15,7 +15,7 @@
       "token": "TO BE PICKED FROM ENV"
     },
     "etSyaApi": {
-      "host": "http://localhost:4550/"
+      "host": "http://localhost:8081/"
     },
     "pcq": {
       "url": "https://pcq.aat.platform.hmcts.net/service-endpoint",

--- a/config/test.json
+++ b/config/test.json
@@ -1,7 +1,7 @@
 {
   "services": {
     "etSyaApi": {
-      "host": "http://localhost:4550/"
+      "host": "http://localhost:8081/"
     }
   }
 }


### PR DESCRIPTION
Default et-syr to et-cos for APIs