### PR TITLE
Pin Jenkins library to 2.4.0

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -11,7 +11,7 @@ parameters([
         ])
 ])
 
-@Library("Infrastructure")
+@Library("Infrastructure@2.4.0")
 import uk.gov.hmcts.contino.AppPipelineDsl
 
 def type = "nodejs"

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -13,7 +13,7 @@ parameters([
         ])
 ])
 
-@Library("Infrastructure")
+@Library("Infrastructure@2.4.0")
 
 def yarnBuilder = new uk.gov.hmcts.contino.YarnBuilder(this)
 def type = "nodejs"


### PR DESCRIPTION
## What changed

Pinned the Jenkins shared library to `Infrastructure@2.4.0` in the standard and nightly pipeline definitions.

## Why

This follows the Jenkins library migration guidance and removes the `old_library_version` deprecation warning before its enforcement deadline. Pinning also ensures pipeline behaviour does not change unexpectedly with the library default branch.

## Impact

Jenkins pipelines will load the approved 2.4.0 shared-library release instead of the unpinned default branch.

## Validation

- `git diff --check`
- Verified no bare `@Library("Infrastructure")` declaration remains in the Jenkins pipeline files
