### PR TITLE
implement CUIYS - Do not merge

### DIFF
--- a/charts/et-syr/Chart.yaml
+++ b/charts/et-syr/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: '1.0'
 description: A Helm chart for et-syr App
 name: et-syr
 home: https://github.com/hmcts/et-syr-frontend
-version: 1.0.11
+version: 1.0.12
 dependencies:
   - name: nodejs
     version: 3.2.1

--- a/charts/et-syr/values.aat.template.yaml
+++ b/charts/et-syr/values.aat.template.yaml
@@ -6,6 +6,7 @@ nodejs:
   devmemoryRequests: 512Mi
   environment:
     OAUTH_CLIENT_REDIRECT: https://${SERVICE_FQDN}/oauth2/callback
+    CUI_URL: 'https://cui-ra.{{ .Values.global.environment }}.platform.hmcts.net'
   keyVaults:
     et:
       resourceGroup: et

--- a/charts/et-syr/values.preview.template.yaml
+++ b/charts/et-syr/values.preview.template.yaml
@@ -14,6 +14,8 @@ nodejs:
         - os-places-token
         - pcq-token-key
         - launch-darkly-sdk-key
+  environment:
+    CUI_URL: 'https://cui-ra.{{ .Values.global.environment }}.platform.hmcts.net'
 idam-pr:
   enabled: true
   redirect_uris:

--- a/charts/et-syr/values.yaml
+++ b/charts/et-syr/values.yaml
@@ -29,5 +29,6 @@ nodejs:
     MANAGE_ORG_URL: 'https://manage-org.{{ .Values.global.environment }}.platform.hmcts.net'
     MANAGE_CASE_URL: 'https://manage-case.{{ .Values.global.environment }}.platform.hmcts.net'
     S2S_URL: 'http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal'
+    CUI_URL: 'https://manage-your-support-for-hmcts-services.service.gov.uk'
 idam-pr:
   enabled: false

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -1,7 +1,10 @@
 {
-    "services": {
-        "s2s": {
-            "url": "S2S_URL"
-        }
+  "services": {
+    "s2s": {
+      "url": "S2S_URL"
+    },
+    "cui": {
+      "endpoint": "CUI_URL"
     }
+  }
 }

--- a/config/default.json
+++ b/config/default.json
@@ -55,6 +55,10 @@
     "s2s": {
       "secret": "TO BE PICKED UP FROM ENV",
       "url": "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
+    },
+    "cui": {
+      "endpoint": "https://cui-ra.aat.platform.hmcts.net",
+      "hmctsServiceId": "BHA1"
     }
   },
   "pact": {

--- a/config/default.json
+++ b/config/default.json
@@ -54,7 +54,8 @@
     },
     "s2s": {
       "secret": "TO BE PICKED UP FROM ENV",
-      "url": "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
+      "url": "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal",
+      "serviceName": "et_syr"
     },
     "cui": {
       "endpoint": "https://cui-ra.aat.platform.hmcts.net",

--- a/config/development.json
+++ b/config/development.json
@@ -25,6 +25,10 @@
     },
     "launchDarkly": {
       "key": "TO BE PICKED FROM ENV"
+    },
+    "cui": {
+      "endpoint": "https://localhost:3100",
+      "hmctsServiceId": "ABA5"
     }
   },
   "session": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "@faker-js/faker": "^9.0.0",
     "@hmcts/cookie-manager": "^1.0.0",
+    "@hmcts/cui-client": "^1.0.0",
     "@hmcts/info-provider": "^1.3.0",
     "@hmcts/nodejs-healthcheck": "^1.8.6",
     "@hmcts/nodejs-logging": "^4.0.4",
@@ -91,6 +92,7 @@
     "mochawesome": "^7.1.4",
     "multer": "^2.1.1",
     "nunjucks": "^3.2.4",
+    "otplib": "^13.4.1",
     "playwright": "^1.56.1",
     "postcode": "^5.1.0",
     "prettier": "^2.8.7",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@faker-js/faker": "^9.0.0",
     "@hmcts/cookie-manager": "^1.0.0",
-    "@hmcts/cui-client": "^1.0.0",
+    "@hmcts/cui-client": "^1.0.1",
     "@hmcts/info-provider": "^1.3.0",
     "@hmcts/nodejs-healthcheck": "^1.8.6",
     "@hmcts/nodejs-logging": "^4.0.4",

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -39,6 +39,7 @@ new Helmet(config.get('security'), [
   process.env.PCQ_URL ?? config.get('services.pcq.url'),
   process.env.ET1_BASE_URL ?? config.get('services.et1Legacy.url'),
   process.env.ET3_LEGACY_URL ? config.get('services.et1Legacy.url') : LegacyUrls.SIGN_UP,
+  process.env.CUI_URL ?? config.get('services.cui.endpoint'),
 ]).enableFor(app);
 
 new I18Next().enableFor(app);

--- a/src/main/controllers/CheckYourAnswersHearingPreferencesController.ts
+++ b/src/main/controllers/CheckYourAnswersHearingPreferencesController.ts
@@ -28,7 +28,7 @@ export default class CheckYourAnswersHearingPreferencesController extends BaseCY
       this.form,
       ET3HubLinkNames.EmployerDetails,
       linkStatus,
-      PageUrls.RESPONDENT_RESPONSE_TASK_LIST
+      PageUrls.YOUR_SUPPORT
     );
   };
 

--- a/src/main/controllers/HearingPreferencesController.ts
+++ b/src/main/controllers/HearingPreferencesController.ts
@@ -51,7 +51,7 @@ export default class HearingPreferencesController {
       this.form,
       ET3HubLinkNames.EmployerDetails,
       LinkStatus.IN_PROGRESS,
-      PageUrls.REASONABLE_ADJUSTMENTS
+      PageUrls.RESPONDENT_EMPLOYEES
     );
   };
 

--- a/src/main/controllers/RespondentResponseTaskListController.ts
+++ b/src/main/controllers/RespondentResponseTaskListController.ts
@@ -4,6 +4,7 @@ import { AppRequest } from '../definitions/appRequest';
 import { ApiDocumentTypeItem } from '../definitions/complexTypes/documentTypeItem';
 import { PageUrls, TranslationKeys, languages } from '../definitions/constants';
 import {
+  ET3CaseDetailsLinkNames,
   ET3HubLinkNames,
   SectionIndexToEt3HubLinkNamesWithEmployersContractClaim,
   getResponseHubLinkStatusesByRespondentHubLinkStatuses,
@@ -13,6 +14,7 @@ import { AnyRecord } from '../definitions/util-types';
 import { setUrlLanguage } from '../helpers/LanguageHelper';
 import { getET3HubLinksUrlMap, shouldCaseDetailsLinkBeClickable } from '../helpers/ResponseHubHelper';
 import { getLanguageParam } from '../helpers/RouterHelpers';
+import { getYourSupportLinkStatus } from '../helpers/controller/CaseDetailsHelper';
 import { getFlagValue } from '../modules/featureFlag/launchDarkly';
 import DocumentUtils from '../utils/DocumentUtils';
 
@@ -54,6 +56,17 @@ export default class RespondentResponseTaskListController {
         }),
       };
     });
+    const yourSupportStatus = getYourSupportLinkStatus(req);
+    const yourSupportLanguageParam =
+      languageParam === languages.WELSH_URL_PARAMETER ? languages.WELSH_URL_PARAMETER : '';
+    sections[0].links.push({
+      linkTxt: (l: AnyRecord): string => l[ET3CaseDetailsLinkNames.YourSupport],
+      status: (l: AnyRecord): string => l[yourSupportStatus],
+      shouldShow: shouldCaseDetailsLinkBeClickable(yourSupportStatus),
+      url: () => PageUrls.YOUR_SUPPORT + yourSupportLanguageParam,
+      statusColor: () => linkStatusColorMap.get(yourSupportStatus),
+    });
+
     res.render(TranslationKeys.RESPONDENT_RESPONSE_TASK_LIST, {
       ...req.t(TranslationKeys.COMMON as never, { returnObjects: true } as never),
       ...req.t(TranslationKeys.CASE_DETAILS_STATUS as never, { returnObjects: true } as never),

--- a/src/main/controllers/YourSupportController.ts
+++ b/src/main/controllers/YourSupportController.ts
@@ -359,7 +359,7 @@ export default class YourSupportController {
 
   private getCuiCompletionUrl(req: AppRequest): string {
     const confirmationUrl = !this.isEt3ResponseSubmitted(req)
-      ? PageUrls.RESPONDENT_RESPONSE_TASK_LIST
+      ? PageUrls.YOUR_SUPPORT_CONFIRMATION
       : PageUrls.YOUR_SUPPORT_SUBMITTED_CONFIRMATION;
 
     return setUrlLanguage(req, confirmationUrl);

--- a/src/main/controllers/YourSupportController.ts
+++ b/src/main/controllers/YourSupportController.ts
@@ -1,0 +1,386 @@
+import { Response } from 'express';
+
+import { Form } from '../components/form';
+import { AppRequest } from '../definitions/appRequest';
+import { CaseWithId, YesOrNo } from '../definitions/case';
+import { AuthUrls, PageUrls, TranslationKeys } from '../definitions/constants';
+import { CaseState } from '../definitions/definition';
+import { FormContent, FormFields } from '../definitions/form';
+import { AnyRecord } from '../definitions/util-types';
+import { handleUpdateDraftCase, handleUpdateSubmittedCaseFlags, setUserCase } from '../helpers/CaseHelpers';
+import { getPageContent } from '../helpers/FormHelper';
+import { setUrlLanguage } from '../helpers/LanguageHelper';
+import { getLanguageCode, returnValidUrl } from '../helpers/RouterHelpers';
+import { buildCuiFlagDetails, mergeRespondentExternalFlags } from '../helpers/controller/CuiFlagHelper';
+import { getLogger } from '../logger';
+
+import {
+  CUIActions,
+  type CUIClient,
+  type CUIFlagDetails,
+  type CUIJourneyData,
+  type CUIStartJourneyAuth,
+  type CUIStartJourneyRequest,
+  type CUIStartJourneyResponse,
+  getCuiService,
+} from './../services/CuiService';
+import type { IS2SService } from './../services/S2SService';
+import { getServiceUrl } from './../utils/getServiceUrl';
+
+const logger = getLogger('YourSupportController');
+const CUI_MASTER_FLAG_CODE = 'RA0001';
+
+const YOUR_SUPPORT_TEMPLATE = 'your-support';
+const YOUR_SUPPORT_CONFIRMATION_TEMPLATE = 'your-support-confirmation';
+const YOUR_SUPPORT_SUBMITTED_CONFIRMATION_TEMPLATE = 'your-support-submitted-confirmation';
+
+const YOUR_SUPPORT_FIELD = 'reasonableAdjustments';
+const YOUR_SUPPORT_REDIRECT_ERROR = 'yourSupportRedirect';
+
+const formatError = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.stack || error.message;
+  }
+
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+};
+
+export default class YourSupportController {
+  private s2sService?: IS2SService;
+  private readonly form: Form;
+
+  private readonly yourSupportContent: FormContent = {
+    fields: {
+      reasonableAdjustments: {
+        id: YOUR_SUPPORT_FIELD,
+        type: 'text',
+        hidden: true,
+        label: (l: AnyRecord): string => l.legend,
+        labelHidden: true,
+      },
+    },
+  };
+
+  constructor(s2sService?: IS2SService) {
+    this.s2sService = s2sService;
+    this.form = new Form(<FormFields>this.yourSupportContent.fields);
+  }
+
+  public get = async (req: AppRequest, res: Response): Promise<void> => {
+    if (!this.canAccessYourSupport(req)) {
+      res.redirect(this.getFallbackUrl(req));
+      return;
+    }
+
+    const content = getPageContent(req, this.yourSupportContent, [
+      TranslationKeys.COMMON,
+      TranslationKeys.YOUR_SUPPORT,
+    ]);
+    const cancelLink = this.getExitUrl(req);
+    const sessionErrors = req.session?.errors || [];
+    req.session.errors = [];
+
+    res.render(YOUR_SUPPORT_TEMPLATE, {
+      ...content,
+      cancelLink,
+      sessionErrors,
+      showNoSupport: this.isDraftCase(req),
+      supportNo: YesOrNo.NO,
+      supportYes: YesOrNo.YES,
+    });
+  };
+
+  public post = async (req: AppRequest, res: Response): Promise<void> => {
+    if (!this.canAccessYourSupport(req)) {
+      res.redirect(this.getFallbackUrl(req));
+      return;
+    }
+
+    const formData: Partial<CaseWithId> = this.form.getParsedBody<CaseWithId>(req.body, this.form.getFormFields());
+    setUserCase(req, formData, []);
+
+    switch (req.session.userCase?.reasonableAdjustments) {
+      case YesOrNo.YES:
+        return this.redirectToCuiJourney(req, res);
+      case YesOrNo.NO:
+        return this.redirectNoSupport(req, res);
+      default:
+        return this.redirectWithRequiredError(req, res);
+    }
+  };
+
+  public redirectToCuiJourney = async (req: AppRequest, res: Response): Promise<void> => {
+    req.session.errors = [];
+
+    try {
+      const results = await this.startCuiJourney(req);
+
+      if (!results || !results.url) {
+        logger.error('No URL returned from CUI service');
+        res.redirect(PageUrls.CASE_DETAILS_WITHOUT_CASE_ID_PARAMETER);
+        return;
+      }
+
+      res.redirect(results.url);
+    } catch (error) {
+      req.session.errors.push({ propertyName: YOUR_SUPPORT_REDIRECT_ERROR, errorType: 'required' });
+      logger.error(`Error starting CUI journey: ${formatError(error)}`);
+      res.redirect(setUrlLanguage(req, PageUrls.YOUR_SUPPORT));
+    }
+  };
+
+  public callback = async (req: AppRequest, res: Response): Promise<void> => {
+    try {
+      const result = await this.getCuiJourneyData(req);
+      this.validateJourneyCorrelationId(req, result);
+
+      if (!this.isSubmittedJourney(result)) {
+        logger.info(
+          `CUI journey completed with action "${result.action}", redirecting back to case page without updating flags`
+        );
+        res.redirect(this.getExitUrl(req, true));
+        return;
+      }
+
+      await this.saveSubmittedJourney(req, result);
+      res.redirect(this.getCuiCompletionUrl(req));
+    } catch (error) {
+      logger.error('Error retrieving CUI journey data', error);
+      res.redirect(PageUrls.CASE_DETAILS_WITHOUT_CASE_ID_PARAMETER);
+    }
+  };
+
+  public confirmation = async (req: AppRequest, res: Response): Promise<void> => {
+    const link = this.getExitUrl(req);
+    this.renderConfirmation(
+      req,
+      res,
+      TranslationKeys.YOUR_SUPPORT_CONFIRMATION,
+      YOUR_SUPPORT_CONFIRMATION_TEMPLATE,
+      link
+    );
+  };
+
+  public submittedConfirmation = async (req: AppRequest, res: Response): Promise<void> => {
+    this.renderConfirmation(
+      req,
+      res,
+      TranslationKeys.YOUR_SUPPORT_SUBMITTED_CONFIRMATION,
+      YOUR_SUPPORT_SUBMITTED_CONFIRMATION_TEMPLATE,
+      this.getExitUrl(req)
+    );
+  };
+
+  private async redirectNoSupport(req: AppRequest, res: Response): Promise<void> {
+    req.session.errors = [];
+    await this.updateDraftCaseIfNeeded(req);
+    res.redirect(this.getExitUrl(req, true));
+  }
+
+  private redirectWithRequiredError(req: AppRequest, res: Response): void {
+    req.session.errors = [{ propertyName: YOUR_SUPPORT_FIELD, errorType: 'required' }];
+    res.redirect(setUrlLanguage(req, PageUrls.YOUR_SUPPORT));
+  }
+
+  private async updateDraftCaseIfNeeded(req: AppRequest): Promise<void> {
+    if (this.isDraftCase(req)) {
+      await handleUpdateDraftCase(req, logger);
+    }
+  }
+
+  private async startCuiJourney(req: AppRequest): Promise<CUIStartJourneyResponse> {
+    return this.getCuiClient(req).startJourney(this.getStartJourneyRequest(req), await this.getStartJourneyAuth(req));
+  }
+
+  private getStartJourneyRequest(req: AppRequest): CUIStartJourneyRequest {
+    return {
+      callbackUrl: getServiceUrl(req, PageUrls.YOUR_SUPPORT_CALLBACK),
+      correlationId: this.getCaseId(req),
+      existingFlags: this.getExistingFlags(req),
+      language: getLanguageCode(req.url),
+      masterFlagCode: CUI_MASTER_FLAG_CODE,
+    };
+  }
+
+  private async getStartJourneyAuth(req: AppRequest): Promise<CUIStartJourneyAuth> {
+    return {
+      serviceToken: await this.getS2SService().getToken(),
+      idamToken: req.session.user?.accessToken ?? '',
+    };
+  }
+
+  private getExistingFlags(req: AppRequest): CUIFlagDetails {
+    const userCase = req.session?.userCase;
+    return buildCuiFlagDetails(userCase?.respondentExternalFlags, this.getPartyName(req), this.getRoleOnCase(req));
+  }
+
+  private getPartyName(req: AppRequest): string {
+    const userCase = req.session?.userCase;
+    return (
+      this.getName(req.session?.user?.givenName, req.session?.user?.familyName) ||
+      userCase?.respondentName ||
+      this.getName(userCase?.firstName, userCase?.lastName) ||
+      userCase?.respondentExternalFlags?.partyName ||
+      'Respondent'
+    );
+  }
+
+  private getName(firstName?: string, lastName?: string): string {
+    return [firstName, lastName].filter(Boolean).join(' ');
+  }
+
+  private getRoleOnCase(req: AppRequest): string {
+    return req.session?.userCase?.respondentRepresented ? 'Representative' : 'Respondent';
+  }
+
+  private async getCuiJourneyData(req: AppRequest): Promise<CUIJourneyData> {
+    return this.getCuiClient(req).getJourneyData(this.getJourneyId(req), {
+      serviceToken: await this.getS2SService().getToken(),
+    });
+  }
+
+  private getJourneyId(req: AppRequest): string {
+    const id = req.params.id;
+    return String(Array.isArray(id) ? id[0] : id ?? '');
+  }
+
+  private validateJourneyCorrelationId(req: AppRequest, result: CUIJourneyData): void {
+    if (result.correlationId !== this.getCaseId(req)) {
+      throw new Error('Correlation ID does not match case ID');
+    }
+  }
+
+  private isSubmittedJourney(result: CUIJourneyData): boolean {
+    return result.action === CUIActions.SUBMIT;
+  }
+
+  private async saveSubmittedJourney(req: AppRequest, result: CUIJourneyData): Promise<void> {
+    if (result.replacementFlags === undefined || result.replacementFlags === null) {
+      throw new Error('CUI journey completed without replacement flags');
+    }
+
+    this.setReplacementFlags(req, result.replacementFlags);
+    if (this.isDraftCase(req)) {
+      await handleUpdateDraftCase(req, logger);
+    } else {
+      await handleUpdateSubmittedCaseFlags(req, logger);
+    }
+
+    if (this.isDraftCase(req) && req.session.userCase?.updateDraftCaseError) {
+      throw new Error('Failed to save CUI replacement flags');
+    }
+  }
+
+  private setReplacementFlags(req: AppRequest, replacementFlags: CUIFlagDetails): void {
+    req.session.userCase = {
+      ...req.session.userCase,
+      respondentExternalFlags: mergeRespondentExternalFlags(
+        req.session.userCase?.respondentExternalFlags,
+        replacementFlags,
+        this.getPartyName(req),
+        this.getRoleOnCase(req)
+      ),
+    };
+  }
+
+  private getCuiClient(req: AppRequest): CUIClient {
+    return getCuiService(getServiceUrl(req, AuthUrls.LOGOUT));
+  }
+
+  private getCaseId(req: AppRequest): string {
+    return String(req.session?.userCase?.id ?? '');
+  }
+
+  private canAccessYourSupport(req: AppRequest): boolean {
+    return this.isDraftCase(req) || !!req.session?.userCase?.id;
+  }
+
+  private isDraftCase(req: AppRequest): boolean {
+    return req.session?.userCase?.state === CaseState.AWAITING_SUBMISSION_TO_HMCTS;
+  }
+
+  private getFallbackUrl(req: AppRequest): string {
+    const userCase = req.session?.userCase;
+    if (userCase?.id && userCase?.ccdId) {
+      return setUrlLanguage(
+        req,
+        PageUrls.CASE_DETAILS_WITH_CASE_ID_RESPONDENT_CCD_ID_PARAMETERS.replace(':caseId', userCase.id).replace(
+          ':caseSubmissionReference',
+          userCase.ccdId
+        )
+      );
+    }
+
+    return setUrlLanguage(req, PageUrls.CASE_DETAILS_WITHOUT_CASE_ID_PARAMETER);
+  }
+
+  private getExitUrl(req: AppRequest, consumeReturnUrl = false): string {
+    if (req.session?.returnUrl) {
+      const returnUrl = req.session.returnUrl;
+      if (consumeReturnUrl) {
+        req.session.returnUrl = '';
+      }
+      return returnValidUrl(returnUrl);
+    }
+
+    const userCase = req.session?.userCase;
+
+    if (userCase?.state === CaseState.AWAITING_SUBMISSION_TO_HMCTS) {
+      return setUrlLanguage(req, PageUrls.CHECK_YOUR_ANSWERS_EMPLOYERS_CONTRACT_CLAIM);
+    }
+
+    if (userCase?.id && userCase?.ccdId) {
+      return setUrlLanguage(
+        req,
+        PageUrls.CASE_DETAILS_WITH_CASE_ID_RESPONDENT_CCD_ID_PARAMETERS.replace(':caseId', userCase.id).replace(
+          ':caseSubmissionReference',
+          userCase.ccdId
+        )
+      );
+    }
+
+    return setUrlLanguage(req, PageUrls.CASE_DETAILS_WITHOUT_CASE_ID_PARAMETER);
+  }
+
+  private getCuiCompletionUrl(req: AppRequest): string {
+    const confirmationUrl = this.isDraftCase(req)
+      ? PageUrls.YOUR_SUPPORT_CONFIRMATION
+      : PageUrls.YOUR_SUPPORT_SUBMITTED_CONFIRMATION;
+
+    return setUrlLanguage(req, confirmationUrl);
+  }
+
+  private renderConfirmation(
+    req: AppRequest,
+    res: Response,
+    translationKey: string,
+    template: string,
+    link: string
+  ): void {
+    const translations: AnyRecord = {
+      ...req.t(TranslationKeys.COMMON, { returnObjects: true }),
+      ...req.t(translationKey, { returnObjects: true }),
+    };
+    const sessionErrors = req.session?.errors || [];
+    req.session.errors = [];
+
+    res.render(template, {
+      ...translations,
+      sessionErrors,
+      link,
+    });
+  }
+
+  private getS2SService(): IS2SService {
+    if (!this.s2sService) {
+      const { getS2SService } = require('./../services/S2SService') as typeof import('./../services/S2SService');
+      this.s2sService = getS2SService();
+    }
+
+    return this.s2sService;
+  }
+}

--- a/src/main/controllers/YourSupportController.ts
+++ b/src/main/controllers/YourSupportController.ts
@@ -324,7 +324,7 @@ export default class YourSupportController {
     const userCase = req.session?.userCase;
 
     if (userCase?.state === CaseState.AWAITING_SUBMISSION_TO_HMCTS) {
-      return setUrlLanguage(req, PageUrls.CHECK_YOUR_ANSWERS_EMPLOYERS_CONTRACT_CLAIM);
+      return setUrlLanguage(req, PageUrls.RESPONDENT_RESPONSE_TASK_LIST);
     }
 
     const caseDetailsUrl = this.getCaseDetailsUrl(req);
@@ -360,7 +360,7 @@ export default class YourSupportController {
 
   private getCuiCompletionUrl(req: AppRequest): string {
     const confirmationUrl = this.isDraftCase(req)
-      ? PageUrls.YOUR_SUPPORT_CONFIRMATION
+      ? PageUrls.RESPONDENT_RESPONSE_TASK_LIST
       : PageUrls.YOUR_SUPPORT_SUBMITTED_CONFIRMATION;
 
     return setUrlLanguage(req, confirmationUrl);

--- a/src/main/controllers/YourSupportController.ts
+++ b/src/main/controllers/YourSupportController.ts
@@ -304,15 +304,9 @@ export default class YourSupportController {
   }
 
   private getFallbackUrl(req: AppRequest): string {
-    const userCase = req.session?.userCase;
-    if (userCase?.id && userCase?.ccdId) {
-      return setUrlLanguage(
-        req,
-        PageUrls.CASE_DETAILS_WITH_CASE_ID_RESPONDENT_CCD_ID_PARAMETERS.replace(':caseId', userCase.id).replace(
-          ':caseSubmissionReference',
-          userCase.ccdId
-        )
-      );
+    const caseDetailsUrl = this.getCaseDetailsUrl(req);
+    if (caseDetailsUrl) {
+      return setUrlLanguage(req, caseDetailsUrl);
     }
 
     return setUrlLanguage(req, PageUrls.CASE_DETAILS_WITHOUT_CASE_ID_PARAMETER);
@@ -333,17 +327,35 @@ export default class YourSupportController {
       return setUrlLanguage(req, PageUrls.CHECK_YOUR_ANSWERS_EMPLOYERS_CONTRACT_CLAIM);
     }
 
-    if (userCase?.id && userCase?.ccdId) {
-      return setUrlLanguage(
-        req,
-        PageUrls.CASE_DETAILS_WITH_CASE_ID_RESPONDENT_CCD_ID_PARAMETERS.replace(':caseId', userCase.id).replace(
-          ':caseSubmissionReference',
-          userCase.ccdId
-        )
-      );
+    const caseDetailsUrl = this.getCaseDetailsUrl(req);
+    if (caseDetailsUrl) {
+      return setUrlLanguage(req, caseDetailsUrl);
     }
 
     return setUrlLanguage(req, PageUrls.CASE_DETAILS_WITHOUT_CASE_ID_PARAMETER);
+  }
+
+  private getCaseDetailsUrl(req: AppRequest): string | undefined {
+    const userCase = req.session?.userCase;
+    const respondentCcdId = this.getSelectedRespondentCcdId(req);
+
+    if (!userCase?.id || !respondentCcdId) {
+      return undefined;
+    }
+
+    return PageUrls.CASE_DETAILS_WITH_CASE_ID_RESPONDENT_CCD_ID_PARAMETERS.replace(
+      ':caseSubmissionReference',
+      userCase.id
+    ).replace(':ccdId', respondentCcdId);
+  }
+
+  private getSelectedRespondentCcdId(req: AppRequest): string | undefined {
+    const selectedRespondentIndex = req.session?.selectedRespondentIndex;
+    if (selectedRespondentIndex === undefined || selectedRespondentIndex === null) {
+      return undefined;
+    }
+
+    return req.session?.userCase?.respondents?.[selectedRespondentIndex]?.ccdId;
   }
 
   private getCuiCompletionUrl(req: AppRequest): string {

--- a/src/main/controllers/YourSupportController.ts
+++ b/src/main/controllers/YourSupportController.ts
@@ -11,6 +11,7 @@ import { handleUpdateDraftCase, handleUpdateSubmittedCaseFlags, setUserCase } fr
 import { getPageContent } from '../helpers/FormHelper';
 import { setUrlLanguage } from '../helpers/LanguageHelper';
 import { getLanguageCode, returnValidUrl } from '../helpers/RouterHelpers';
+import { isEt3ResponseSubmitted as hasEt3ResponseSubmitted } from '../helpers/controller/CaseDetailsHelper';
 import { buildCuiFlagDetails, mergeRespondentExternalFlags } from '../helpers/controller/CuiFlagHelper';
 import { getLogger } from '../logger';
 
@@ -88,7 +89,7 @@ export default class YourSupportController {
       ...content,
       cancelLink,
       sessionErrors,
-      showNoSupport: this.isDraftCase(req),
+      showNoSupport: !this.isEt3ResponseSubmitted(req),
       supportNo: YesOrNo.NO,
       supportYes: YesOrNo.YES,
     });
@@ -321,9 +322,7 @@ export default class YourSupportController {
       return returnValidUrl(returnUrl);
     }
 
-    const userCase = req.session?.userCase;
-
-    if (userCase?.state === CaseState.AWAITING_SUBMISSION_TO_HMCTS) {
+    if (!this.isEt3ResponseSubmitted(req)) {
       return setUrlLanguage(req, PageUrls.RESPONDENT_RESPONSE_TASK_LIST);
     }
 
@@ -359,11 +358,15 @@ export default class YourSupportController {
   }
 
   private getCuiCompletionUrl(req: AppRequest): string {
-    const confirmationUrl = this.isDraftCase(req)
+    const confirmationUrl = !this.isEt3ResponseSubmitted(req)
       ? PageUrls.RESPONDENT_RESPONSE_TASK_LIST
       : PageUrls.YOUR_SUPPORT_SUBMITTED_CONFIRMATION;
 
     return setUrlLanguage(req, confirmationUrl);
+  }
+
+  private isEt3ResponseSubmitted(req: AppRequest): boolean {
+    return hasEt3ResponseSubmitted(req);
   }
 
   private renderConfirmation(

--- a/src/main/definitions/api/caseApiBody.ts
+++ b/src/main/definitions/api/caseApiBody.ts
@@ -1,3 +1,4 @@
+import { CaseFlags } from '../case';
 import { ClaimantTse } from '../complexTypes/ClaimantTse';
 import { ClaimantCorrespondence } from '../complexTypes/claimantCorrespondence';
 import { ClaimantEmploymentDetails } from '../complexTypes/claimantEmploymentDetails';
@@ -21,6 +22,7 @@ interface CaseDataApiBody {
   claimantIndType?: ClaimantIndividual;
   claimantType?: ClaimantCorrespondence;
   claimantHearingPreference?: ClaimantHearingPreference;
+  respondentExternalFlags?: CaseFlags;
   claimantTaskListChecks?: TaskListCheckType;
   claimantOtherType?: ClaimantEmploymentDetails;
   claimantRequests?: ClaimantRequests;

--- a/src/main/definitions/api/caseApiBody.ts
+++ b/src/main/definitions/api/caseApiBody.ts
@@ -46,6 +46,14 @@ export interface UpdateCaseBody {
   case_data: CaseDataApiBody;
 }
 
+export interface UpdateSubmittedCaseFlagsBody {
+  case_id: string;
+  case_type_id: string;
+  case_data: {
+    respondentExternalFlags: CaseFlags;
+  };
+}
+
 export interface RespondentRequestBody {
   value: RespondentType;
   id?: string;

--- a/src/main/definitions/api/caseApiResponse.ts
+++ b/src/main/definitions/api/caseApiResponse.ts
@@ -1,4 +1,4 @@
-import { CaseType, CaseTypeId, Document, RepresentedTypeC, YesOrNo } from '../case';
+import { CaseFlags, CaseType, CaseTypeId, Document, RepresentedTypeC, YesOrNo } from '../case';
 import { ClaimantCorrespondence } from '../complexTypes/claimantCorrespondence';
 import { ClaimantEmploymentDetails } from '../complexTypes/claimantEmploymentDetails';
 import { ClaimantHearingPreference } from '../complexTypes/claimantHearingPreference';
@@ -47,6 +47,7 @@ export interface CaseData {
   newEmploymentType?: NewEmploymentDetails;
   claimantRequests?: ClaimantRequests;
   claimantHearingPreference?: ClaimantHearingPreference;
+  respondentExternalFlags?: CaseFlags;
   claimantTaskListChecks?: TaskListCheckType;
   respondentCollection?: RespondentApiModel[];
   claimantWorkAddressQuestion?: YesOrNo;

--- a/src/main/definitions/case.ts
+++ b/src/main/definitions/case.ts
@@ -14,7 +14,7 @@ import {
 } from './definition';
 import { HubLinksStatuses } from './hub';
 import { ET3CaseDetailsLinksStatuses, ET3HubLinksStatuses } from './links';
-import { UnknownRecord } from './util-types';
+import { TypeItem, UnknownRecord } from './util-types';
 
 export enum Checkbox {
   Checked = 'checked',
@@ -208,6 +208,8 @@ export interface RespondentET3Model extends ET3VettingCommonTypes {
   et3IsRespondentAddressCorrect?: YesOrNo;
   et3Status?: string;
   representativeRemoved?: YesOrNo;
+
+  respondentExternalFlags?: CaseFlags;
 }
 
 export interface RespondentApiModel {
@@ -246,6 +248,7 @@ export interface Case {
   claimantContactPreference?: EmailOrPost;
   claimantContactLanguagePreference?: EnglishOrWelsh;
   claimantHearingLanguagePreference?: EnglishOrWelsh;
+  respondentExternalFlags?: CaseFlags;
   claimantRepresentedQuestion?: YesOrNo;
   caseSource?: string;
   representativeClaimantType?: RepresentedTypeC;
@@ -561,4 +564,32 @@ export interface RepresentedTypeC {
 export interface Organisation {
   organisationID?: string;
   organisationName?: string;
+}
+
+export interface CaseFlags {
+  partyName?: string;
+  roleOnCase?: string;
+  groupId?: string;
+  visibility?: 'Internal' | 'External' | string;
+  details?: TypeItem<FlagDetail>[];
+}
+
+export interface FlagDetail {
+  name?: string;
+  name_cy?: string;
+  subTypeValue?: string;
+  subTypeValue_cy?: string;
+  subTypeKey?: string;
+  otherDescription?: string;
+  otherDescription_cy?: string;
+  flagComment?: string;
+  flagComment_cy?: string;
+  dateTimeModified?: string;
+  dateTimeCreated?: string;
+  path?: TypeItem<string>[];
+  hearingRelevant?: string;
+  flagCode?: string;
+  status?: 'Active' | 'Inactive' | string;
+  requestReason?: string;
+  availableExternally?: string;
 }

--- a/src/main/definitions/constants.ts
+++ b/src/main/definitions/constants.ts
@@ -316,6 +316,7 @@ export const JavaApiUrls = {
   INITIATE_CASE_DRAFT: 'cases/initiate-case',
   UPDATE_CASE_DRAFT: 'cases/update-case',
   SUBMIT_CASE: 'cases/submit-case',
+  UPDATE_SUBMITTED_CASE: 'cases/update-case-submitted',
   ROLE_PARAM_NAME: 'case_user_role',
   MODIFY_ET3_DATA: '/et3/modifyEt3Data',
   FIND_CASE_BY_ETHOS_CASE_REFERENCE_PARAM_NAME: 'ethosCaseReference',

--- a/src/main/definitions/constants.ts
+++ b/src/main/definitions/constants.ts
@@ -97,6 +97,10 @@ export const TranslationKeys = {
   // others
   RETURN_TO_EXISTING_RESPONSE: 'return-to-existing-response',
   CHANGE_LEGAL_REPRESENTATIVE: 'change-legal-representative',
+
+  YOUR_SUPPORT: 'your-support',
+  YOUR_SUPPORT_CONFIRMATION: 'your-support-confirmation',
+  YOUR_SUPPORT_SUBMITTED_CONFIRMATION: 'your-support-submitted-confirmation',
 } as const;
 
 export const PageUrls = {
@@ -200,6 +204,12 @@ export const PageUrls = {
   // others
   RETURN_TO_EXISTING_RESPONSE: '/return-to-existing-response',
   CHANGE_LEGAL_REPRESENTATIVE: '/change-legal-representative',
+
+  YOUR_SUPPORT: '/your-support',
+  YOUR_SUPPORT_REDIRECT: '/your-support-redirect',
+  YOUR_SUPPORT_CALLBACK: '/your-support/:id',
+  YOUR_SUPPORT_CONFIRMATION: '/your-support-confirmation',
+  YOUR_SUPPORT_SUBMITTED_CONFIRMATION: '/your-support-submitted-confirmation',
 } as const;
 
 export const InterceptPaths = {

--- a/src/main/definitions/links.ts
+++ b/src/main/definitions/links.ts
@@ -2,6 +2,7 @@
 //******************************************************************//
 export enum ET3CaseDetailsLinkNames {
   PersonalDetails = 'personalDetails',
+  YourSupport = 'yourSupport',
   ET1ClaimForm = 'et1ClaimForm',
   ClaimantContactDetails = 'claimantContactDetails',
   RespondentResponse = 'respondentResponse',
@@ -22,6 +23,8 @@ export class ET3CaseDetailsLinksStatuses {
     Object.values(ET3CaseDetailsLinkNames).forEach(name => {
       if (name === ET3CaseDetailsLinkNames.PersonalDetails) {
         this[name] = LinkStatus.NOT_YET_AVAILABLE;
+      } else if (name === ET3CaseDetailsLinkNames.YourSupport) {
+        this[name] = LinkStatus.OPTIONAL;
       } else if (name === ET3CaseDetailsLinkNames.ET1ClaimForm) {
         this[name] = LinkStatus.NOT_VIEWED;
       } else if (name === ET3CaseDetailsLinkNames.ClaimantContactDetails) {
@@ -52,7 +55,7 @@ export class ET3CaseDetailsLinksStatuses {
 }
 
 export const SectionIndexToEt3CaseDetailsLinkNames: ET3CaseDetailsLinkNames[][] = [
-  [ET3CaseDetailsLinkNames.PersonalDetails],
+  [ET3CaseDetailsLinkNames.PersonalDetails, ET3CaseDetailsLinkNames.YourSupport],
   [ET3CaseDetailsLinkNames.ET1ClaimForm, ET3CaseDetailsLinkNames.ClaimantContactDetails],
   [ET3CaseDetailsLinkNames.RespondentResponse],
   [ET3CaseDetailsLinkNames.HearingDetails],

--- a/src/main/helpers/ApiFormatter.ts
+++ b/src/main/helpers/ApiFormatter.ts
@@ -106,6 +106,7 @@ export function formatApiCaseDataToCaseWithId(fromApiCaseData: CaseApiDataRespon
     noticeEnds: parseDateFromString(fromApiCaseData.case_data?.claimantOtherType?.claimant_employed_notice_period),
     hearingPreferences: fromApiCaseData.case_data?.claimantHearingPreference?.hearing_preferences,
     hearingAssistance: fromApiCaseData.case_data?.claimantHearingPreference?.hearing_assistance,
+    respondentExternalFlags: fromApiCaseData.case_data?.respondentExternalFlags,
     claimantContactPreference: fromApiCaseData.case_data?.claimantType?.claimant_contact_preference,
     claimantContactLanguagePreference: fromApiCaseData.case_data?.claimantHearingPreference?.contact_language,
     claimantHearingLanguagePreference: fromApiCaseData.case_data?.claimantHearingPreference?.hearing_language,
@@ -521,6 +522,7 @@ export function getUpdateCaseBody(caseItem: CaseWithId): UpdateCaseBody {
         contact_language: caseItem.claimantContactLanguagePreference,
         hearing_language: caseItem.claimantHearingLanguagePreference,
       },
+      respondentExternalFlags: caseItem.respondentExternalFlags,
       claimantRequests: {
         discrimination_claims: caseItem.claimTypeDiscrimination,
         pay_claims: caseItem.claimTypePay,

--- a/src/main/helpers/CaseHelpers.ts
+++ b/src/main/helpers/CaseHelpers.ts
@@ -64,6 +64,16 @@ export const handleUpdateDraftCase = async (req: AppRequest, logger: Logger): Pr
   }
 };
 
+export const handleUpdateSubmittedCaseFlags = async (req: AppRequest, logger: Logger): Promise<void> => {
+  const response = await getCaseApi(req.session.user?.accessToken).updateDraftCase(req.session.userCase);
+  logger.info(`Updated submitted case flags id: ${req.session.userCase.id}`);
+  req.session.userCase = {
+    ...req.session.userCase,
+    ...formatApiCaseDataToCaseWithId(response.data),
+  };
+  req.session.save();
+};
+
 export const setUserCase = (req: AppRequest, formData: Partial<CaseWithId>, fieldsToReset: string[]): void => {
   if (!req.session.userCase) {
     req.session.userCase = {} as CaseWithId;

--- a/src/main/helpers/CaseHelpers.ts
+++ b/src/main/helpers/CaseHelpers.ts
@@ -65,13 +65,18 @@ export const handleUpdateDraftCase = async (req: AppRequest, logger: Logger): Pr
 };
 
 export const handleUpdateSubmittedCaseFlags = async (req: AppRequest, logger: Logger): Promise<void> => {
-  const response = await getCaseApi(req.session.user?.accessToken).updateDraftCase(req.session.userCase);
-  logger.info(`Updated submitted case flags id: ${req.session.userCase.id}`);
-  req.session.userCase = {
-    ...req.session.userCase,
-    ...formatApiCaseDataToCaseWithId(response.data),
-  };
-  req.session.save();
+  try {
+    const response = await getCaseApi(req.session.user?.accessToken).updateSubmittedCaseFlags(req.session.userCase);
+    logger.info(`Updated submitted case flags id: ${req.session.userCase.id}`);
+    req.session.userCase = {
+      ...req.session.userCase,
+      ...formatApiCaseDataToCaseWithId(response.data),
+    };
+    req.session.save();
+  } catch (error) {
+    logger.error(`Failed to update submitted case flags ${req.session.userCase.id}: ${error.message}`);
+    throw error;
+  }
 };
 
 export const setUserCase = (req: AppRequest, formData: Partial<CaseWithId>, fieldsToReset: string[]): void => {

--- a/src/main/helpers/ResponseHubHelper.ts
+++ b/src/main/helpers/ResponseHubHelper.ts
@@ -33,6 +33,7 @@ export const getET3CaseDetailsLinksUrlMap = (
 ): Map<string, string> => {
   const caseDetailsLinksMap = new Map<string, string>();
   caseDetailsLinksMap.set(ET3CaseDetailsLinkNames.PersonalDetails, PageUrls.NOT_IMPLEMENTED + baseUrls[languageParam]);
+  caseDetailsLinksMap.set(ET3CaseDetailsLinkNames.YourSupport, PageUrls.YOUR_SUPPORT + baseUrls[languageParam]);
   caseDetailsLinksMap.set(ET3CaseDetailsLinkNames.ET1ClaimForm, PageUrls.CLAIMANT_ET1_FORM + baseUrls[languageParam]);
   caseDetailsLinksMap.set(
     ET3CaseDetailsLinkNames.ClaimantContactDetails,

--- a/src/main/helpers/RouterHelpers.ts
+++ b/src/main/helpers/RouterHelpers.ts
@@ -10,6 +10,23 @@ import UrlUtils from '../utils/UrlUtils';
 
 import { addParameterToUrl, setUrlLanguage } from './LanguageHelper';
 
+export const validateLanguageParam = (lng: string): boolean => {
+  const validLanguages = [languages.WELSH, languages.ENGLISH];
+  return validLanguages.includes(lng);
+};
+
+export const getLanguageCode = (url: string): string => {
+  if (!url?.includes('?')) {
+    return languages.ENGLISH;
+  }
+  const urlParams = new URLSearchParams(url.split('?')[1]);
+  const lng = urlParams.get('lng');
+  if (lng && validateLanguageParam(lng)) {
+    return lng;
+  }
+  return languages.ENGLISH;
+};
+
 export const getLanguageParam = (url: string): string => {
   if (url?.includes(languages.WELSH_URL_POSTFIX)) {
     return languages.WELSH_URL_PARAMETER;

--- a/src/main/helpers/controller/CaseDetailsHelper.ts
+++ b/src/main/helpers/controller/CaseDetailsHelper.ts
@@ -1,5 +1,5 @@
 import { AppRequest, UserDetails } from '../../definitions/appRequest';
-import { CaseWithId, RespondentET3Model } from '../../definitions/case';
+import { CaseWithId, RespondentET3Model, YesOrNo } from '../../definitions/case';
 import { GenericTseApplicationTypeItem } from '../../definitions/complexTypes/genericTseApplicationTypeItem';
 import { TranslationKeys } from '../../definitions/constants';
 import {
@@ -39,7 +39,7 @@ export const getET3CaseDetailsLinkNames = async (
   statuses = getResponseCaseDetailsLinkStatusesByRespondentCaseDetailsLinkStatuses(statuses);
   await updateApplicationsStatusIfNotExist(req);
   statuses[ET3CaseDetailsLinkNames.ClaimantContactDetails] = LinkStatus.READY_TO_VIEW;
-  statuses[ET3CaseDetailsLinkNames.YourSupport] = getYourSupportLinkStatus(req);
+  statuses[ET3CaseDetailsLinkNames.YourSupport] = getYourSupportCaseDetailsLinkStatus(req);
   statuses[ET3CaseDetailsLinkNames.YourRequestsAndApplications] = getYourRequestsAndApplications(req);
   statuses[ET3CaseDetailsLinkNames.ClaimantApplications] = getClaimantAppsLinkStatus(req);
   statuses[ET3CaseDetailsLinkNames.OtherRespondentApplications] = getOtherRespondentAppsLinkStatus(req);
@@ -84,6 +84,21 @@ const getOtherRespondentAppsLinkStatus = (req: AppRequest): LinkStatus => {
 
 export const getYourSupportLinkStatus = (req: AppRequest): LinkStatus => {
   return req.session?.userCase?.respondentExternalFlags?.details?.length ? LinkStatus.SUBMITTED : LinkStatus.OPTIONAL;
+};
+
+export const isEt3ResponseSubmitted = (req: AppRequest): boolean => {
+  const userCase = req.session?.userCase;
+  const selectedRespondentIndex = req.session?.selectedRespondentIndex;
+  const selectedRespondent =
+    selectedRespondentIndex === undefined || selectedRespondentIndex === null
+      ? undefined
+      : userCase?.respondents?.[selectedRespondentIndex];
+
+  return userCase?.responseReceived === YesOrNo.YES || selectedRespondent?.responseReceived === YesOrNo.YES;
+};
+
+const getYourSupportCaseDetailsLinkStatus = (req: AppRequest): LinkStatus => {
+  return isEt3ResponseSubmitted(req) ? getYourSupportLinkStatus(req) : LinkStatus.NOT_YET_AVAILABLE;
 };
 
 const getLinkStatus = (apps: GenericTseApplicationTypeItem[], user: UserDetails, isYours: boolean): LinkStatus => {

--- a/src/main/helpers/controller/CaseDetailsHelper.ts
+++ b/src/main/helpers/controller/CaseDetailsHelper.ts
@@ -39,6 +39,7 @@ export const getET3CaseDetailsLinkNames = async (
   statuses = getResponseCaseDetailsLinkStatusesByRespondentCaseDetailsLinkStatuses(statuses);
   await updateApplicationsStatusIfNotExist(req);
   statuses[ET3CaseDetailsLinkNames.ClaimantContactDetails] = LinkStatus.READY_TO_VIEW;
+  statuses[ET3CaseDetailsLinkNames.YourSupport] = getYourSupportLinkStatus(req);
   statuses[ET3CaseDetailsLinkNames.YourRequestsAndApplications] = getYourRequestsAndApplications(req);
   statuses[ET3CaseDetailsLinkNames.ClaimantApplications] = getClaimantAppsLinkStatus(req);
   statuses[ET3CaseDetailsLinkNames.OtherRespondentApplications] = getOtherRespondentAppsLinkStatus(req);
@@ -79,6 +80,10 @@ const getOtherRespondentAppsLinkStatus = (req: AppRequest): LinkStatus => {
   const apps =
     userCase?.genericTseApplicationCollection?.filter(app => isOtherRespApplicationShare(app.value, user)) || [];
   return getLinkStatus(apps, user, false);
+};
+
+const getYourSupportLinkStatus = (req: AppRequest): LinkStatus => {
+  return req.session?.userCase?.respondentExternalFlags?.details?.length ? LinkStatus.SUBMITTED : LinkStatus.OPTIONAL;
 };
 
 const getLinkStatus = (apps: GenericTseApplicationTypeItem[], user: UserDetails, isYours: boolean): LinkStatus => {

--- a/src/main/helpers/controller/CaseDetailsHelper.ts
+++ b/src/main/helpers/controller/CaseDetailsHelper.ts
@@ -82,7 +82,7 @@ const getOtherRespondentAppsLinkStatus = (req: AppRequest): LinkStatus => {
   return getLinkStatus(apps, user, false);
 };
 
-const getYourSupportLinkStatus = (req: AppRequest): LinkStatus => {
+export const getYourSupportLinkStatus = (req: AppRequest): LinkStatus => {
   return req.session?.userCase?.respondentExternalFlags?.details?.length ? LinkStatus.SUBMITTED : LinkStatus.OPTIONAL;
 };
 

--- a/src/main/helpers/controller/CheckYourAnswersET3Helper.ts
+++ b/src/main/helpers/controller/CheckYourAnswersET3Helper.ts
@@ -7,7 +7,6 @@ import {
   TypeOfOrganisation,
   YesOrNo,
   YesOrNoOrNotApplicable,
-  YesOrNoOrNotSure,
 } from '../../definitions/case';
 import { Et1Address } from '../../definitions/complexTypes/et1Address';
 import { DefaultValues, PageUrls } from '../../definitions/constants';
@@ -192,32 +191,6 @@ export const getEt3Section2 = (
       hideChangeLink ? undefined : sectionCya
     )
   );
-
-  et3ResponseSection2.push(
-    addSummaryRowWithAction(
-      translations.section2.disabilitySupport,
-      {
-        [YesOrNoOrNotSure.YES]: translations.oesYesOrNo.yes,
-        [YesOrNoOrNotSure.NO]: translations.oesYesOrNo.no,
-        [YesOrNoOrNotSure.NOT_SURE]: translations.section2.disabilitySupportNotSure,
-      }[userCase.et3ResponseRespondentSupportNeeded] ?? translations.notProvided,
-      PageUrls.REASONABLE_ADJUSTMENTS,
-      hideChangeLink ? undefined : translations.change,
-      hideChangeLink ? undefined : sectionCya
-    )
-  );
-
-  if (YesOrNoOrNotSure.YES === userCase.et3ResponseRespondentSupportNeeded) {
-    et3ResponseSection2.push(
-      addSummaryRowWithAction(
-        translations.section2.supportRequest,
-        userCase.et3ResponseRespondentSupportDetails,
-        PageUrls.REASONABLE_ADJUSTMENTS,
-        hideChangeLink ? undefined : translations.change,
-        hideChangeLink ? undefined : sectionCya
-      )
-    );
-  }
 
   et3ResponseSection2.push(
     addSummaryRowWithAction(

--- a/src/main/helpers/controller/CuiFlagHelper.ts
+++ b/src/main/helpers/controller/CuiFlagHelper.ts
@@ -1,0 +1,126 @@
+import type { CaseFlags } from '../../definitions/case';
+import type { AnyRecord } from '../../definitions/util-types';
+import {
+  type CUIFlag,
+  type CUIFlagDetails,
+  type CUIFlagItem,
+  type CUIFlagPath,
+  mergeCUIFlagItems,
+} from '../../services/CuiService';
+
+const CUI_FLAG_OPTIONAL_FIELDS = [
+  'subTypeValue',
+  'subTypeValue_cy',
+  'subTypeKey',
+  'otherDescription',
+  'otherDescription_cy',
+  'flagComment',
+  'flagComment_cy',
+  'flagUpdateComment',
+  'dateTimeModified',
+  'status',
+];
+
+export const buildCuiFlagDetails = (
+  respondentExternalFlags: CaseFlags | undefined,
+  partyName: string,
+  roleOnCase: string
+): CUIFlagDetails => {
+  return {
+    partyName,
+    roleOnCase: respondentExternalFlags?.roleOnCase || roleOnCase,
+    details: getExistingFlagDetails(respondentExternalFlags?.details),
+  };
+};
+
+export const mergeRespondentExternalFlags = (
+  existingFlags: CaseFlags | undefined,
+  replacementFlags: CUIFlagDetails,
+  partyName: string,
+  roleOnCase: string
+): CaseFlags => {
+  const details = mergeCUIFlagItems(
+    (existingFlags?.details ?? []) as unknown as CUIFlagItem[],
+    replacementFlags.details
+  );
+
+  return {
+    ...existingFlags,
+    ...replacementFlags,
+    partyName: replacementFlags.partyName || partyName,
+    roleOnCase: replacementFlags.roleOnCase || existingFlags?.roleOnCase || roleOnCase,
+    details,
+  } as unknown as CaseFlags;
+};
+
+const getExistingFlagDetails = (details: CaseFlags['details'] = []): CUIFlagItem[] => {
+  return details.map(flagItem => {
+    const cuiFlagItem = {
+      value: getExistingFlagValue(flagItem.value as AnyRecord),
+    } as Partial<CUIFlagItem>;
+
+    if (flagItem.id) {
+      cuiFlagItem.id = flagItem.id;
+    }
+
+    return cuiFlagItem as CUIFlagItem;
+  });
+};
+
+const getExistingFlagValue = (flagValue: AnyRecord): CUIFlag => {
+  const cuiFlag: AnyRecord = {
+    name: flagValue.name ?? '',
+    name_cy: flagValue.name_cy ?? '',
+    dateTimeCreated: flagValue.dateTimeCreated ?? '',
+    path: getExistingFlagPath(flagValue.path),
+    hearingRelevant: flagValue.hearingRelevant ?? 'No',
+    flagCode: flagValue.flagCode ?? '',
+    availableExternally: flagValue.availableExternally ?? 'Yes',
+  };
+
+  CUI_FLAG_OPTIONAL_FIELDS.forEach(field => {
+    if (flagValue[field] !== undefined) {
+      cuiFlag[field] = flagValue[field];
+    }
+  });
+
+  return cuiFlag as CUIFlag;
+};
+
+const getExistingFlagPath = (path: unknown): CUIFlagPath[] => {
+  if (!Array.isArray(path)) {
+    return [];
+  }
+
+  return path
+    .map(pathItem => getExistingFlagPathItem(pathItem))
+    .filter((pathItem): pathItem is CUIFlagPath => !!pathItem);
+};
+
+const getExistingFlagPathItem = (pathItem: unknown): CUIFlagPath | undefined => {
+  const pathItemRecord = pathItem as AnyRecord;
+  const id = pathItemRecord?.id ? { id: pathItemRecord.id } : {};
+
+  if (pathItemRecord?.name) {
+    return {
+      ...id,
+      name: pathItemRecord.name,
+    };
+  }
+
+  if (typeof pathItemRecord?.value === 'string') {
+    return {
+      ...id,
+      name: pathItemRecord.value,
+    };
+  }
+
+  if (pathItemRecord?.value?.name) {
+    return {
+      ...id,
+      name: pathItemRecord.value.name,
+    };
+  }
+
+  return undefined;
+};

--- a/src/main/modules/routes/routes.ts
+++ b/src/main/modules/routes/routes.ts
@@ -104,6 +104,7 @@ import SessionTimeoutController from '../../controllers/SessionTimeoutController
 import TypeOfOrganisationController from '../../controllers/TypeOfOrganisationController';
 import YourRequestAndApplicationsController from '../../controllers/YourRequestAndApplicationsController';
 import YourResponseFormController from '../../controllers/YourResponseFormController';
+import YourSupportController from '../../controllers/YourSupportController';
 import { AppRequest } from '../../definitions/appRequest';
 import { FILE_SIZE_LIMIT, FormFieldNames, InterceptPaths, PageUrls, Urls } from '../../definitions/constants';
 
@@ -155,6 +156,11 @@ export class Routes {
     app.get(PageUrls.CASE_DETAILS_WITH_CASE_ID_RESPONDENT_CCD_ID_PARAMETERS, new CaseDetailsController().get);
     app.get(PageUrls.NEW_SELF_ASSIGNMENT_REQUEST, new NewSelfAssignmentRequestController().get);
     app.get(PageUrls.COOKIE_PREFERENCES, new CookiePreferencesController().get);
+    app.get(PageUrls.YOUR_SUPPORT, new YourSupportController().get);
+    app.post(PageUrls.YOUR_SUPPORT, new YourSupportController().post);
+    app.get(PageUrls.YOUR_SUPPORT_CALLBACK, new YourSupportController().callback);
+    app.get(PageUrls.YOUR_SUPPORT_CONFIRMATION, new YourSupportController().confirmation);
+    app.get(PageUrls.YOUR_SUPPORT_SUBMITTED_CONFIRMATION, new YourSupportController().submittedConfirmation);
     app.get(PageUrls.APPLICATION_SUBMITTED, new ApplicationSubmittedController().get);
     app.get(PageUrls.RESPONSE_SAVED, new ResponseSavedController().get);
     app.get(PageUrls.CHECK_YOUR_ANSWERS_ET3, new CheckYourAnswersET3Controller().get);

--- a/src/main/resources/locales/cy/translation/case-details.json
+++ b/src/main/resources/locales/cy/translation/case-details.json
@@ -18,6 +18,7 @@
   "section7": "Dyfarniadau gan y tribiwnlys",
   "section8": "Dogfennau’r achos",
   "personalDetails": "Gweld a golygu eich manylion personol",
+  "yourSupport": "Your Support",
   "et1ClaimForm": "Ffurflen hawlio ET1 yr hawlydd",
   "claimantContactDetails": "Gweld manylion cyswllt yr hawlydd",
   "respondentResponse": "Eich ffurflen ymateb (ET3)",

--- a/src/main/resources/locales/cy/translation/respondent-response-task-list.json
+++ b/src/main/resources/locales/cy/translation/respondent-response-task-list.json
@@ -9,6 +9,7 @@
   "section1": "Dywedwch wrthym am yr atebydd",
   "contactDetails": "Manylion cyswllt",
   "employerDetails": "Fformat y gwrandawiad a manylion y cyflogwr",
+  "yourSupport": "Your Support",
   "section2": "Dywedwch wrthym am yr hawlydd ",
   "conciliationAndEmployeeDetails": "Cymodi cynnar a manylion gweithiwr",
   "payPensionBenefitDetails": "Manylion cyflog, pensiwn a buddion",

--- a/src/main/resources/locales/cy/translation/your-support-confirmation.json
+++ b/src/main/resources/locales/cy/translation/your-support-confirmation.json
@@ -1,0 +1,14 @@
+{
+  "title": "Rydych wedi ychwanegu eich cais am gymorth at eich hawliad",
+  "h1": "Rydych wedi ychwanegu eich cais am gymorth at eich hawliad",
+  "h2": "Beth sy'n digwydd nesaf",
+  "legend": "Eich cymorth",
+  "p": "Ar ôl ichi gyflwyno eich hawliad, bydd y tribiwnlys yn adolygu eich cais am gymorth ac yn cysylltu â chi os bydd angen mwy o wybodaeth arno. Gallwch ddweud wrthym os bydd eich anghenion cymorth yn newid ar ôl ichi gyflwyno eich hawliad.",
+  "buttonText": "Parhau â'ch hawliad",
+  "textAreaHint": "Gallwch ddisgrifio'r hyn sydd ei angen arnoch",
+  "errors": {
+    "reasonableAdjustmentsDetail": {
+      "required": "Rhowch fanylion y cymorth sydd ei angen arnoch"
+    }
+  }
+}

--- a/src/main/resources/locales/cy/translation/your-support-confirmation.json
+++ b/src/main/resources/locales/cy/translation/your-support-confirmation.json
@@ -1,10 +1,10 @@
 {
-  "title": "Rydych wedi ychwanegu eich cais am gymorth at eich hawliad",
-  "h1": "Rydych wedi ychwanegu eich cais am gymorth at eich hawliad",
+  "title": "Rydych chi wedi ychwanegu eich cais am gymorth at eich hawliad",
+  "h1": "Rydych chi wedi ychwanegu eich cais am gymorth at eich hawliad",
   "h2": "Beth sy'n digwydd nesaf",
   "legend": "Eich cymorth",
-  "p": "Ar ôl ichi gyflwyno eich hawliad, bydd y tribiwnlys yn adolygu eich cais am gymorth ac yn cysylltu â chi os bydd angen mwy o wybodaeth arno. Gallwch ddweud wrthym os bydd eich anghenion cymorth yn newid ar ôl ichi gyflwyno eich hawliad.",
-  "buttonText": "Parhau â'ch hawliad",
+  "p": "Unwaith i chi gyflwyno eich hawliad, bydd y tribiwnlys yn adolygu eich cais am gymorth ac yn cysylltu â chi os oes angen rhagor o wybodaeth arno. Gallwch ddweud wrthym os yw eich anghenion cymorth yn newid ar ôl i chi gyflwyno eich hawliad.",
+  "buttonText": "Parhau gyda'ch hawliad",
   "textAreaHint": "Gallwch ddisgrifio'r hyn sydd ei angen arnoch",
   "errors": {
     "reasonableAdjustmentsDetail": {

--- a/src/main/resources/locales/cy/translation/your-support-submitted-confirmation.json
+++ b/src/main/resources/locales/cy/translation/your-support-submitted-confirmation.json
@@ -1,0 +1,8 @@
+{
+  "title": "Rydych wedi ychwanegu eich cais am gymorth",
+  "h1": "Rydych wedi ychwanegu eich cais am gymorth",
+  "h2": "Beth sy'n digwydd nesaf",
+  "p": "Bydd y tribiwnlys yn adolygu eich cais am gymorth ac yn cysylltu â chi os bydd angen mwy o wybodaeth arno.",
+  "p2": "Os oes angen i chi ofyn am rywbeth nad yw wedi'i restru ar eich cyfer chi neu rywun sy'n eich cefnogi, cysylltwch â'r tribiwnlys yn uniongyrchol o'ch trosolwg achos.",
+  "buttonText": "Dychwelyd i drosolwg yr achos"
+}

--- a/src/main/resources/locales/cy/translation/your-support-submitted-confirmation.json
+++ b/src/main/resources/locales/cy/translation/your-support-submitted-confirmation.json
@@ -3,6 +3,7 @@
   "h1": "Rydych wedi ychwanegu eich cais am gymorth",
   "h2": "Beth sy'n digwydd nesaf",
   "p": "Bydd y tribiwnlys yn adolygu eich cais am gymorth ac yn cysylltu â chi os bydd angen mwy o wybodaeth arno.",
-  "p2": "Os oes angen i chi ofyn am rywbeth nad yw wedi'i restru ar eich cyfer chi neu rywun sy'n eich cefnogi, cysylltwch â'r tribiwnlys yn uniongyrchol o'ch trosolwg achos.",
+  "p2": "Gallwch newid eich anghenion cymorth unrhyw bryd yn 'Eich cymorth' o'ch trosolwg achos.",
+  "p3": "Os oes angen i chi ofyn am rywbeth nad yw wedi'i restru ar eich cyfer chi neu rywun sy'n eich cefnogi, cysylltwch â'r tribiwnlys yn uniongyrchol o'ch trosolwg achos.",
   "buttonText": "Dychwelyd i drosolwg yr achos"
 }

--- a/src/main/resources/locales/cy/translation/your-support-submitted-confirmation.json
+++ b/src/main/resources/locales/cy/translation/your-support-submitted-confirmation.json
@@ -1,9 +1,8 @@
 {
-  "title": "Rydych wedi ychwanegu eich cais am gymorth",
-  "h1": "Rydych wedi ychwanegu eich cais am gymorth",
-  "h2": "Beth sy'n digwydd nesaf",
-  "p": "Bydd y tribiwnlys yn adolygu eich cais am gymorth ac yn cysylltu â chi os bydd angen mwy o wybodaeth arno.",
-  "p2": "Gallwch newid eich anghenion cymorth unrhyw bryd yn 'Eich cymorth' o'ch trosolwg achos.",
-  "p3": "Os oes angen i chi ofyn am rywbeth nad yw wedi'i restru ar eich cyfer chi neu rywun sy'n eich cefnogi, cysylltwch â'r tribiwnlys yn uniongyrchol o'ch trosolwg achos.",
+  "title": "Rydych wedi anfon eich cais am gymorth i'r tribiwnlys",
+  "h1": "Rydych wedi anfon eich cais am gymorth i'r tribiwnlys",
+  "h2": "Beth fydd yn digwydd nesaf",
+  "p": "Bydd y tribiwnlys yn adolygu eich cais ac yn dweud wrthych beth yw eu penderfyniad, neu a oes angen rhagor o wybodaeth gennych.",
+  "p2": "Gallwch newid eich anghenion cymorth unrhyw bryd yn yr adran 'Eich cymorth' o drosolwg eich achos. Os oes angen i chi ofyn am rywbeth nad yw wedi'i restru ar eich cyfer chi neu rywun sy'n eich cefnogi, cysylltwch â'r tribiwnlys yn uniongyrchol o drosolwg eich achos.",
   "buttonText": "Dychwelyd i drosolwg yr achos"
 }

--- a/src/main/resources/locales/cy/translation/your-support.json
+++ b/src/main/resources/locales/cy/translation/your-support.json
@@ -1,0 +1,78 @@
+{
+  "title": "Tell us if you need support",
+  "h1": "Tell us if you need support",
+  "legend": "Your Support",
+  "p": "Some people need support to use HMCTS service. You can ask for:",
+  "detailsSummary": {
+    "subheading": "Examples of reasonable adjustments are:",
+    "p": "You can also tell us if you're able to attend a remote hearing.",
+    "bullet1": "a language interpreter",
+    "bullet2": "reasonable adjustments for people with a health condition or disability",
+    "bullet3": "special measures to feel safe at court",
+    "bullet4": "regular breaks during a hearing"
+  },
+  "details": [
+    {
+      "header": "Support before a court or tribunal hearing",
+      "blocks": [
+        {
+          "paragraph": "If you need support before your hearing. for example a reasonable adjustment for alternative formats like large print. You can ask for support at any time during your case."
+        }
+      ]
+    },
+    {
+      "header": "Support at a hearing",
+      "blocks": [
+        {
+          "paragraph": "Not everyone has to attend a hearing. If you need to attend a hearing were you know and you can tell us what support you need."
+        }
+      ]
+    },
+    {
+      "header": "Support for someone else",
+      "blocks": [
+        {
+          "paragraph": "If someone you're bringing to the hearing needs support, contact us using details on the main page of your account."
+        }
+      ]
+    },
+    {
+      "header": "What happens next",
+      "blocks": [
+        {
+          "paragraph": "Once you've submitted your request for support, it'll be reviewed by HMCTS or a judge. We'll keep you updated on status of request in your account. If we need more information we'll contact you."
+        },
+        {
+          "paragraph": "Examples of other support are:"
+        },
+        {
+          "bulletList": [
+            "communication and documents in Welsh or to speak Welsh at your hearing",
+            "a language interpreter",
+            "special measures, like giving evidence in private because you are vulnerable"
+          ]
+        },
+        {
+          "paragraph": "After you submit your claim, you can contact the tribunal dealing with your claim to ask for something else."
+        }
+      ]
+    }
+  ],
+  "yes": "Yes",
+  "continueToQuestions": "Continue to the questions",
+  "noSupport": "I do not need any support at this time",
+  "adjustmentDetailTextLabel": "Tell us what support you need to request",
+  "textAreaHint": "You can describe to us what you need",
+  "startNow": "Start now",
+  "errors": {
+    "reasonableAdjustments": {
+      "required": "Select whether you need support"
+    },
+    "yourSupportRedirect": {
+      "required": "There was a problem starting your support request. Try again later."
+    },
+    "reasonableAdjustmentsDetail": {
+      "required": "Give details of the support you need"
+    }
+  }
+}

--- a/src/main/resources/locales/cy/translation/your-support.json
+++ b/src/main/resources/locales/cy/translation/your-support.json
@@ -60,7 +60,7 @@
   ],
   "yes": "Oes",
   "continueToQuestions": "Ymlaen i'r cwestiynau",
-  "noSupport": "Nac oes, nid oes arnaf angen unrhyw gymorth ar hyn o bryd",
+  "noSupport": "Nid oes arnaf angen unrhyw gymorth ar hyn o bryd",
   "adjustmentDetailTextLabel": "Dywedwch wrthym pa gymorth rydych angen gofyn amdano",
   "textAreaHint": "Gallwch ddisgrifio beth sydd ei angen arnoch",
   "startNow": "Dechrau",

--- a/src/main/resources/locales/cy/translation/your-support.json
+++ b/src/main/resources/locales/cy/translation/your-support.json
@@ -1,78 +1,78 @@
 {
-  "title": "Tell us if you need support",
-  "h1": "Tell us if you need support",
-  "legend": "Your Support",
-  "p": "Some people need support to use HMCTS service. You can ask for:",
+  "title": "Dywedwch wrthym os oes arnoch angen cymorth",
+  "h1": "Dywedwch wrthym os oes arnoch angen cymorth",
+  "legend": "Eich Cymorth",
+  "p": "Mae rhai pobl angen cymorth i gael mynediad at wybodaeth ac i ddefnyddio ein gwasanaethau. Gelwir hyn yn aml yn addasiad rhesymol.",
   "detailsSummary": {
-    "subheading": "Examples of reasonable adjustments are:",
-    "p": "You can also tell us if you're able to attend a remote hearing.",
-    "bullet1": "a language interpreter",
-    "bullet2": "reasonable adjustments for people with a health condition or disability",
-    "bullet3": "special measures to feel safe at court",
-    "bullet4": "regular breaks during a hearing"
+    "subheading": "Dyma enghreifftiau o addasiadau rhesymol:",
+    "bullet1": "mynediad di-risiau os yw'ch achos yn mynd i wrandawiad ac mae'n cael ei gynnal wyneb yn wyneb",
+    "bullet2": "dod â chymorth gyda chi i'r gwrandawiad, fel rhywun rydych chi'n ei adnabod neu gi cymorth",
+    "bullet3": "dogfennau mewn fformat amgen, fel print bras",
+    "bullet4": "seibiannau rheolaidd yn ystod gwrandawiad",
+    "p": "Gallwch wneud cais am addasiad rhesymol nawr drwy ddewis 'Ymlaen i'r cwestiynau', neu ar unrhyw adeg ar ôl i chi gyflwyno'ch hawliad. Byddwn yn dweud wrthych sut i wneud hyn."
   },
   "details": [
     {
-      "header": "Support before a court or tribunal hearing",
+      "header": "Cymorth cyn gwrandawiad tribiwnlys",
       "blocks": [
         {
-          "paragraph": "If you need support before your hearing. for example a reasonable adjustment for alternative formats like large print. You can ask for support at any time during your case."
+          "paragraph": "Os oes angen cymorth arnoch cyn eich gwrandawiad, er enghraifft addasiad rhesymol ar gyfer fformatau amgen fel print bras, gallwch ofyn am gymorth ar unrhyw adeg yn ystod eich achos."
         }
       ]
     },
     {
-      "header": "Support at a hearing",
+      "header": "Cymorth mewn gwrandawiad",
       "blocks": [
         {
-          "paragraph": "Not everyone has to attend a hearing. If you need to attend a hearing were you know and you can tell us what support you need."
+          "paragraph": "Nid oes rhaid i bawb fynychu gwrandawiad. Byddwn yn rhoi gwybod i chi os oes angen i chi fynychu gwrandawiad - yna gallwch ddweud wrthym pa gymorth y bydd ei angen arnoch. Ystyriwch wrandawiadau o bell a rhai wyneb yn wyneb, rhag ofn bod y math o wrandawiad o'ch dewis ddim yn bosibl."
         }
       ]
     },
     {
-      "header": "Support for someone else",
+      "header": "Cymorth i rywun arall",
       "blocks": [
         {
-          "paragraph": "If someone you're bringing to the hearing needs support, contact us using details on the main page of your account."
+          "paragraph": "Os oes angen cymorth ar rywun sy'n dod gyda chi i'r gwrandawiad, cysylltwch â'r tribiwnlys ar ôl i chi gyflwyno'ch hawliad."
         }
       ]
     },
     {
-      "header": "What happens next",
+      "header": "Gwneud cais am rywbeth arall",
       "blocks": [
         {
-          "paragraph": "Once you've submitted your request for support, it'll be reviewed by HMCTS or a judge. We'll keep you updated on status of request in your account. If we need more information we'll contact you."
+          "paragraph": "Rhaid i chi gysylltu â'r tribiwnlys yn uniongyrchol i wneud cais am rywbeth arall ar eich cyfer chi neu rywun arall sy'n dod i'r llys i'ch cefnogi."
         },
         {
-          "paragraph": "Examples of other support are:"
+          "paragraph": "Dyma enghreifftiau o gymorth arall:"
         },
         {
           "bulletList": [
-            "communication and documents in Welsh or to speak Welsh at your hearing",
-            "a language interpreter",
-            "special measures, like giving evidence in private because you are vulnerable"
+            "cyfathrebu a dogfennau yn y Gymraeg neu i siarad yn y Gymraeg yn eich gwrandawiad",
+            "cyfieithydd",
+            "mesurau arbennig, fel rhoi tystiolaeth yn breifat, oherwydd eich bod yn agored i niwed"
           ]
         },
         {
-          "paragraph": "After you submit your claim, you can contact the tribunal dealing with your claim to ask for something else."
+          "paragraph": "Ar ôl i chi gyflwyno eich hawliad, gallwch gysylltu â'r tribiwnlys sy'n delio â'ch hawliad i ofyn am rywbeth arall."
         }
       ]
     }
   ],
-  "yes": "Yes",
-  "continueToQuestions": "Continue to the questions",
-  "noSupport": "I do not need any support at this time",
-  "adjustmentDetailTextLabel": "Tell us what support you need to request",
-  "textAreaHint": "You can describe to us what you need",
-  "startNow": "Start now",
+  "yes": "Oes",
+  "continueToQuestions": "Ymlaen i'r cwestiynau",
+  "noSupport": "Nac oes, nid oes arnaf angen unrhyw gymorth ar hyn o bryd",
+  "adjustmentDetailTextLabel": "Dywedwch wrthym pa gymorth rydych angen gofyn amdano",
+  "textAreaHint": "Gallwch ddisgrifio beth sydd ei angen arnoch",
+  "startNow": "Dechrau",
   "errors": {
     "reasonableAdjustments": {
-      "required": "Select whether you need support"
+      "required": "Dewiswch a oes arnoch angen cymorth"
     },
     "yourSupportRedirect": {
-      "required": "There was a problem starting your support request. Try again later."
+      "required": "Roedd problem wrth ddechrau eich cais am gymorth. Ceisiwch eto yn nes ymlaen."
     },
     "reasonableAdjustmentsDetail": {
-      "required": "Give details of the support you need"
+      "required": "Rhowch fanylion am y cymorth sydd ei angen arnoch"
     }
   }
 }

--- a/src/main/resources/locales/en/translation/case-details.json
+++ b/src/main/resources/locales/en/translation/case-details.json
@@ -18,6 +18,7 @@
   "section7": "Judgments from the tribunal",
   "section8": "Case documents",
   "personalDetails": "View and edit your personal details",
+  "yourSupport": "Your Support",
   "et1ClaimForm": "The claimant's ET1 claim form",
   "claimantContactDetails": "View claimant contact details",
   "respondentResponse": "Your response form (ET3)",

--- a/src/main/resources/locales/en/translation/respondent-response-task-list.json
+++ b/src/main/resources/locales/en/translation/respondent-response-task-list.json
@@ -9,6 +9,7 @@
   "section1": "Tell us about the respondent",
   "contactDetails": "Contact details",
   "employerDetails": "Hearing format and employer details",
+  "yourSupport": "Your Support",
   "section2": "Tell us about the claimant ",
   "conciliationAndEmployeeDetails": "Early conciliation and employee details",
   "payPensionBenefitDetails": "Pay, pension and benefits details",

--- a/src/main/resources/locales/en/translation/your-support-confirmation.json
+++ b/src/main/resources/locales/en/translation/your-support-confirmation.json
@@ -1,0 +1,14 @@
+{
+  "title": "You have added your support request to your claim",
+  "h1": "You have added your support request to your claim",
+  "h2": "What happens next",
+  "legend": "",
+  "p": "Once you submit your claim, the tribunal will review your support request and contact you if it needs any more information. You can tell us if your support needs change after you submit your claim.",
+  "buttonText": "Continue your claim",
+  "textAreaHint": "You can describe to us what you need",
+  "errors": {
+    "reasonableAdjustmentsDetail": {
+      "required": "Give details of the support you need"
+    }
+  }
+}

--- a/src/main/resources/locales/en/translation/your-support-submitted-confirmation.json
+++ b/src/main/resources/locales/en/translation/your-support-submitted-confirmation.json
@@ -1,0 +1,8 @@
+{
+  "title": "You have sent your support request to the tribunal",
+  "h1": "You have sent your support request to the tribunal",
+  "h2": "What happens next",
+  "p": "The tribunal will review your request and tell you its decision, or if it needs more information from you.",
+  "p2": "If you need to ask for something not listed for you or someone supporting you, contact the tribunal directly from your case overview.",
+  "buttonText": "Return to case overview"
+}

--- a/src/main/resources/locales/en/translation/your-support-submitted-confirmation.json
+++ b/src/main/resources/locales/en/translation/your-support-submitted-confirmation.json
@@ -3,6 +3,7 @@
   "h1": "You have sent your support request to the tribunal",
   "h2": "What happens next",
   "p": "The tribunal will review your request and tell you its decision, or if it needs more information from you.",
-  "p2": "If you need to ask for something not listed for you or someone supporting you, contact the tribunal directly from your case overview.",
+  "p2": "You can change your support needs at any time in 'Your support' from your case overview.",
+  "p3": "If you need to ask for something not listed for you or someone supporting you, contact the tribunal directly from your case overview.",
   "buttonText": "Return to case overview"
 }

--- a/src/main/resources/locales/en/translation/your-support-submitted-confirmation.json
+++ b/src/main/resources/locales/en/translation/your-support-submitted-confirmation.json
@@ -4,6 +4,5 @@
   "h2": "What happens next",
   "p": "The tribunal will review your request and tell you its decision, or if it needs more information from you.",
   "p2": "You can change your support needs at any time in 'Your support' from your case overview.",
-  "p3": "If you need to ask for something not listed for you or someone supporting you, contact the tribunal directly from your case overview.",
   "buttonText": "Return to case overview"
 }

--- a/src/main/resources/locales/en/translation/your-support.json
+++ b/src/main/resources/locales/en/translation/your-support.json
@@ -1,0 +1,78 @@
+{
+  "title": "Tell us if you need support",
+  "h1": "Tell us if you need support",
+  "legend": "Your Support",
+  "p": "Some people need support to access information and use our services. We call this a reasonable adjustment.",
+  "detailsSummary": {
+    "subheading": "Examples of reasonable adjustments are:",
+    "bullet1": "step-free access if your case goes to a hearing and it happens in person",
+    "bullet2": "bringing support with you to the hearing, like someone you know or an assistance dog",
+    "bullet3": "documents in an alternative format, like large print",
+    "bullet4": "regular breaks during a hearing",
+    "p": "You can ask for a reasonable adjustment now by selecting ‘Continue to the questions’ or at any time after you submit your claim. We will tell you how to do this."
+  },
+  "details": [
+    {
+      "header": "Support before a tribunal hearing",
+      "blocks": [
+        {
+          "paragraph": "If you need support before your hearing, for example a reasonable adjustment for alternative formats like large print, you can ask for support at any time during your case."
+        }
+      ]
+    },
+    {
+      "header": "Support at a hearing",
+      "blocks": [
+        {
+          "paragraph": "Not everyone has to attend a hearing.  We will tell you if you need to attend a hearing -  you can then tell us what support you need. Consider remote and in-person hearings in case your preferred hearing type is not possible."
+        }
+      ]
+    },
+    {
+      "header": "Support for someone else",
+      "blocks": [
+        {
+          "paragraph": "If someone you are bringing to the hearing needs support, contact the tribunal after you submit your claim."
+        }
+      ]
+    },
+    {
+      "header": "Ask for something else",
+      "blocks": [
+        {
+          "paragraph": "You must contact the tribunal directly to ask for something else for you or someone else who is coming to court to support you."
+        },
+        {
+          "paragraph": "Examples of other support are:"
+        },
+        {
+          "bulletList": [
+            "communication and documents in Welsh or to speak Welsh at your hearing",
+            "a language interpreter",
+            "special measures, like giving evidence in private because you are vulnerable"
+          ]
+        },
+        {
+          "paragraph": "After you submit your claim, you can contact the tribunal dealing with your claim to ask for something else."
+        }
+      ]
+    }
+  ],
+  "yes": "Yes",
+  "continueToQuestions": "Continue to the questions",
+  "noSupport": "I do not need any support at this time",
+  "adjustmentDetailTextLabel": "Tell us what support you need to request",
+  "textAreaHint": "You can describe to us what you need",
+  "startNow": "Start now",
+  "errors": {
+    "reasonableAdjustments": {
+      "required": "Select whether you need support"
+    },
+    "yourSupportRedirect": {
+      "required": "There was a problem starting your support request. Try again later."
+    },
+    "reasonableAdjustmentsDetail": {
+      "required": "Give details of the support you need"
+    }
+  }
+}

--- a/src/main/services/CaseService.ts
+++ b/src/main/services/CaseService.ts
@@ -2,6 +2,7 @@ import axiosService, { AxiosInstance, AxiosResponse } from 'axios';
 import config from 'config';
 import FormData from 'form-data';
 
+import { UpdateSubmittedCaseFlagsBody } from '../definitions/api/caseApiBody';
 import { CaseApiDataResponse, CaseAssignmentResponse } from '../definitions/api/caseApiResponse';
 import { DocumentUploadResponse } from '../definitions/api/documentApiResponse';
 import { UploadedFile } from '../definitions/api/uploadedFile';
@@ -29,6 +30,26 @@ export class CaseApi {
       return await this.axios.put(JavaApiUrls.UPDATE_CASE_DRAFT, toApiFormat(caseItem));
     } catch (error) {
       throw new Error(ServiceErrors.ERROR_UPDATING_DRAFT_CASE + axiosErrorDetails(error));
+    }
+  };
+
+  updateSubmittedCaseFlags = async (caseItem: CaseWithId): Promise<AxiosResponse<CaseApiDataResponse>> => {
+    try {
+      if (!caseItem.respondentExternalFlags) {
+        throw new Error('respondentExternalFlags must be set');
+      }
+
+      const updateSubmittedCaseFlagsBody: UpdateSubmittedCaseFlagsBody = {
+        case_id: caseItem.id,
+        case_type_id: caseItem.caseTypeId,
+        case_data: {
+          respondentExternalFlags: caseItem.respondentExternalFlags,
+        },
+      };
+
+      return await this.axios.post(JavaApiUrls.UPDATE_SUBMITTED_CASE, updateSubmittedCaseFlagsBody);
+    } catch (error) {
+      throw new Error('Error updating submitted case flags: ' + axiosErrorDetails(error));
     }
   };
 

--- a/src/main/services/CuiService.ts
+++ b/src/main/services/CuiService.ts
@@ -3,6 +3,7 @@ import https from 'https';
 import { CUIClient, type CUIClientConfig, type CUIClientOptions } from '@hmcts/cui-client';
 import config from 'config';
 
+export { CUIActions, mergeCUIFlagItems } from '@hmcts/cui-client';
 export type { CUIClient } from '@hmcts/cui-client';
 export type {
   CUIClientConfig,
@@ -15,6 +16,7 @@ export type {
   CUIFlagDetails,
   CUIFlagItem,
   CUIFlagPath,
+  CUIJourneyAction,
   CUIJourneyData,
 } from '@hmcts/cui-client';
 

--- a/src/main/services/CuiService.ts
+++ b/src/main/services/CuiService.ts
@@ -1,0 +1,45 @@
+import https from 'https';
+
+import { CUIClient, type CUIClientConfig, type CUIClientOptions } from '@hmcts/cui-client';
+import config from 'config';
+
+export type { CUIClient } from '@hmcts/cui-client';
+export type {
+  CUIClientConfig,
+  CUIClientOptions,
+  CUIStartJourneyAuth,
+  CUIStartJourneyRequest,
+  CUIStartJourneyResponse,
+  CUIClientAuth,
+  CUIFlag,
+  CUIFlagDetails,
+  CUIFlagItem,
+  CUIFlagPath,
+  CUIJourneyData,
+} from '@hmcts/cui-client';
+
+export const getCuiService = (loginUrl: string | null = null): CUIClient => {
+  const cuiClientConfig = config.get<CUIClientConfig>('services.cui');
+  const env = process.env.NODE_ENV || 'development';
+
+  if (!cuiClientConfig) {
+    throw new Error('Missing required configuration for CUI service');
+  }
+
+  const resolvedCuiClientConfig: CUIClientConfig = {
+    ...cuiClientConfig,
+    ...(loginUrl ? { logoutUrl: loginUrl } : {}),
+  };
+
+  if (env === 'development') {
+    return new CUIClient(resolvedCuiClientConfig, {
+      axiosConfig: {
+        httpsAgent: new https.Agent({
+          rejectUnauthorized: false,
+        }),
+      },
+    } as CUIClientOptions);
+  }
+
+  return new CUIClient(resolvedCuiClientConfig);
+};

--- a/src/main/services/S2SService.ts
+++ b/src/main/services/S2SService.ts
@@ -1,0 +1,68 @@
+import axios, { isAxiosError } from 'axios';
+import config from 'config';
+import { OTP, createGuardrails } from 'otplib';
+
+const otp = new OTP({
+  guardrails: createGuardrails({
+    MIN_SECRET_BYTES: 10,
+  }),
+});
+
+export interface IS2SService {
+  getOneTimeToken(): Promise<string>;
+  getToken(): Promise<string>;
+}
+
+export class S2SService implements IS2SService {
+  constructor(private endpoint: string, private secret: string, private serviceName: string) {}
+
+  public async getOneTimeToken(): Promise<string> {
+    try {
+      return await otp.generate({ secret: this.secret });
+    } catch (error) {
+      throw new Error(
+        `Failed to generate one-time token for service "${this.serviceName}": ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  }
+
+  public async getToken(): Promise<string> {
+    const url = `${this.endpoint}/lease`;
+    const body = {
+      microservice: this.serviceName,
+      oneTimePassword: await this.getOneTimeToken(),
+    };
+
+    try {
+      const response = await axios.post(url, body);
+      if (response.status !== 200) {
+        throw new Error(`S2S lease request returned unexpected status ${response.status} from ${url}`);
+      }
+      if (typeof response.data !== 'string') {
+        throw new Error(`S2S lease response from ${url} had unexpected data type: ${typeof response.data}`);
+      }
+      return response.data;
+    } catch (error) {
+      if (isAxiosError(error)) {
+        const status = error.response?.status ?? 'no response';
+        const detail = error.response?.data ? JSON.stringify(error.response.data) : error.message;
+        throw new Error(`S2S lease request to ${url} failed (status ${status}): ${detail}`);
+      }
+      throw error;
+    }
+  }
+}
+
+export const getS2SService = (): IS2SService => {
+  const endpoint = config.get<string>('services.s2s.url');
+  const secret = config.get<string>('services.s2s.secret');
+  const serviceName = config.get<string>('services.s2s.serviceName');
+  if (!endpoint || !secret || !serviceName) {
+    throw new Error(
+      'Missing required configuration for S2S service: endpoint, secret, and serviceName must all be provided'
+    );
+  }
+  return new S2SService(endpoint, secret, serviceName);
+};

--- a/src/main/utils/getServiceUrl.ts
+++ b/src/main/utils/getServiceUrl.ts
@@ -1,0 +1,11 @@
+import config from 'config';
+import { Request } from 'express';
+
+import { HTTPS_PROTOCOL } from '../definitions/constants';
+
+export const getServiceUrl = (req: Request, path = ''): string => {
+  const host = (req.headers['x-forwarded-host'] || req.hostname) as string;
+  const port = req.app.locals.developmentMode ? `:${config.get('port')}` : '';
+
+  return `${HTTPS_PROTOCOL}${host}${port}${path}`;
+};

--- a/src/main/views/your-support-confirmation.njk
+++ b/src/main/views/your-support-confirmation.njk
@@ -1,0 +1,30 @@
+{% extends "template.njk" %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block beforeContent %}
+  {{ super() }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-panel govuk-panel--interruption">
+    <h1 class="govuk-panel__title">
+      {{ h1 }}
+    </h1>
+  </div>
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-4">{{ h2 }}</h2>
+  <p class="govuk-body ">{{ p }}</p>
+  <div class="govuk-button-group">
+    {{ govukButton({
+      text: buttonText,
+      preventDoubleClick: true,
+      href: link,
+      attributes: {
+        id: 'continue-to-next-step'
+      }
+    })  }}
+  </div>
+
+{% endblock %}

--- a/src/main/views/your-support-confirmation.njk
+++ b/src/main/views/your-support-confirmation.njk
@@ -1,4 +1,4 @@
-{% extends "template.njk" %}
+{% extends "form/main/template.njk" %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}

--- a/src/main/views/your-support-submitted-confirmation.njk
+++ b/src/main/views/your-support-submitted-confirmation.njk
@@ -1,0 +1,29 @@
+{% extends "template.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block beforeContent %}
+  {{ super() }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-panel govuk-panel--confirmation">
+    <h1 class="govuk-panel__title">
+      {{ h1 }}
+    </h1>
+  </div>
+
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-4">{{ h2 }}</h2>
+  <p class="govuk-body">{{ p }}</p>
+  <p class="govuk-body">{{ p2 }}</p>
+
+  <div class="govuk-button-group">
+    {{ govukButton({
+      text: buttonText,
+      preventDoubleClick: true,
+      href: link,
+      attributes: {
+        id: 'return-to-case-overview'
+      }
+    }) }}
+  </div>
+{% endblock %}

--- a/src/main/views/your-support-submitted-confirmation.njk
+++ b/src/main/views/your-support-submitted-confirmation.njk
@@ -1,4 +1,4 @@
-{% extends "template.njk" %}
+{% extends "form/main/template.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block beforeContent %}

--- a/src/main/views/your-support.njk
+++ b/src/main/views/your-support.njk
@@ -1,0 +1,102 @@
+{% extends "template.njk" %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+
+{% block beforeContent %}
+  {{ super() }}
+  {% include "back-link.njk"%}
+{% endblock %}
+
+{% block content %}
+
+  {% block errorSummary %}
+    {% set yourSupportRedirectError = getError('yourSupportRedirect') %}
+    {% set reasonableAdjustmentsError = getError('reasonableAdjustments') %}
+    {% set errors = [] %}
+    {% if yourSupportRedirectError %}
+      {% set _ = errors.push({
+        text: yourSupportRedirectError.text,
+        href: '#start-support-request'
+      }) %}
+    {% endif %}
+    {% if reasonableAdjustmentsError %}
+      {% set _ = errors.push({
+        text: reasonableAdjustmentsError.text,
+        href: '#start-support-request'
+      }) %}
+    {% endif %}
+    {{
+      govukErrorSummary({
+        titleText: errorSummaryTitle,
+        errorList: errors
+      }) if errors.length > 0
+    }}
+  {% endblock %}
+      
+<h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
+<span class="govuk-caption-l">{{ legend }}</span>
+{{ h1 }}
+</h1>
+<p class="govuk-body">{{ p }}</p>
+<div>
+    <p class="govuk-body">{{ detailsSummary.subheading }}</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>{{ detailsSummary.bullet1 }} </li>
+      <li>{{ detailsSummary.bullet2 }} </li>        
+      <li>{{ detailsSummary.bullet3 }} </li>
+      <li>{{ detailsSummary.bullet4 }} </li>
+    </ul>
+    <p class="govuk-body ">{{ detailsSummary.p }}</p>
+    {% for item in details %}
+      <h2 class="govuk-heading-m">{{ item.header }}</h2>
+      {% if item.blocks %}
+        {% for contentBlock in item.blocks %}
+          {% if contentBlock.paragraph %}
+            <p class="govuk-body">{{ contentBlock.paragraph }}</p>
+          {% elif contentBlock.bulletList %}
+            <ul class="govuk-list govuk-list--bullet">
+              {% for bullet in contentBlock.bulletList %}
+                <li>{{ bullet }}</li>
+              {% endfor %}
+            </ul>
+          {% endif %}
+        {% endfor %}
+      {% else %}
+        {% for paragraph in item.paragraphs %}
+          <p class="govuk-body">{{ paragraph.text }}</p>
+        {% endfor %}
+      {% endif %}
+    {% endfor %}
+</div>
+
+{% block form %}
+  <form class="form" id="main-form" method="post" action="" novalidate="true">
+    <input type="hidden" name="_csrf" value={{ csrfToken }}>
+    <div class="govuk-button-group">
+      {{ govukButton({
+        text: continueToQuestions,
+        preventDoubleClick: true,
+        name: 'reasonableAdjustments',
+        value: supportYes,
+        attributes: {
+          id: 'start-support-request'
+        }
+      })  }}
+
+      {{ govukButton({
+        text: noSupport,
+        classes: 'govuk-button--secondary',
+        preventDoubleClick: true,
+        name: 'reasonableAdjustments',
+        value: supportNo,
+        attributes: {
+          id: 'no-support-request'
+        }
+      }) if showNoSupport }}
+
+    </div>
+  </form>
+{% endblock %}
+{% endblock %}

--- a/src/main/views/your-support.njk
+++ b/src/main/views/your-support.njk
@@ -1,4 +1,4 @@
-{% extends "template.njk" %}
+{% extends "form/main/template.njk" %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/src/test/unit/controllers/CheckYourAnswersHearingPreferencesController.test.ts
+++ b/src/test/unit/controllers/CheckYourAnswersHearingPreferencesController.test.ts
@@ -49,12 +49,12 @@ describe('CheckYourAnswersHearingPreferencesController', () => {
   });
 
   describe('POST method', () => {
-    it('should go to the respondent response task list on valid submission when Yes is selected', async () => {
+    it('should go to your support on valid submission when Yes is selected', async () => {
       (conditionalRedirect as jest.Mock).mockReturnValue(true);
 
       updateET3ResponseWithET3FormMock.mockImplementation(
         createMockedUpdateET3ResponseWithET3FormFunction(
-          PageUrls.RESPONDENT_RESPONSE_TASK_LIST,
+          PageUrls.YOUR_SUPPORT,
           request,
           response,
           [],
@@ -65,23 +65,23 @@ describe('CheckYourAnswersHearingPreferencesController', () => {
       await controller.post(request, response);
 
       expect(request.session.userCase).toEqual(mockCaseWithIdWithRespondents);
-      expect(response.redirect).toHaveBeenCalledWith(PageUrls.RESPONDENT_RESPONSE_TASK_LIST);
+      expect(response.redirect).toHaveBeenCalledWith(PageUrls.YOUR_SUPPORT);
       expect(updateET3ResponseWithET3FormMock).toHaveBeenCalledWith(
         request,
         response,
         expect.anything(),
         expect.anything(),
         LinkStatus.COMPLETED,
-        PageUrls.RESPONDENT_RESPONSE_TASK_LIST
+        PageUrls.YOUR_SUPPORT
       );
     });
 
-    it('should go to the respondent response task list on valid submission when No is selected', async () => {
+    it('should go to your support on valid submission when No is selected', async () => {
       (conditionalRedirect as jest.Mock).mockReturnValue(false);
 
       updateET3ResponseWithET3FormMock.mockImplementation(
         createMockedUpdateET3ResponseWithET3FormFunction(
-          PageUrls.RESPONDENT_RESPONSE_TASK_LIST,
+          PageUrls.YOUR_SUPPORT,
           request,
           response,
           [],
@@ -92,14 +92,14 @@ describe('CheckYourAnswersHearingPreferencesController', () => {
       await controller.post(request, response);
 
       expect(request.session.userCase).toEqual(mockCaseWithIdWithRespondents);
-      expect(response.redirect).toHaveBeenCalledWith(PageUrls.RESPONDENT_RESPONSE_TASK_LIST);
+      expect(response.redirect).toHaveBeenCalledWith(PageUrls.YOUR_SUPPORT);
       expect(updateET3ResponseWithET3FormMock).toHaveBeenCalledWith(
         request,
         response,
         expect.anything(),
         expect.anything(),
         LinkStatus.IN_PROGRESS_CYA,
-        PageUrls.RESPONDENT_RESPONSE_TASK_LIST
+        PageUrls.YOUR_SUPPORT
       );
     });
 

--- a/src/test/unit/controllers/HearingPreferenceController.test.ts
+++ b/src/test/unit/controllers/HearingPreferenceController.test.ts
@@ -38,10 +38,10 @@ describe('HearingPreferencesController', () => {
           et3ResponseHearingRespondent: HearingPreference.VIDEO,
         },
       });
-      request.url = PageUrls.REASONABLE_ADJUSTMENTS;
+      request.url = PageUrls.RESPONDENT_EMPLOYEES;
       updateET3DataMock.mockResolvedValue(mockCaseWithIdWithRespondents);
       await controller.post(request, response);
-      expect(response.redirect).toHaveBeenCalledWith(PageUrls.REASONABLE_ADJUSTMENTS);
+      expect(response.redirect).toHaveBeenCalledWith(PageUrls.RESPONDENT_EMPLOYEES);
     });
 
     it('should redirect to next page when NEITHER is selected and details is filled in', async () => {
@@ -50,10 +50,10 @@ describe('HearingPreferencesController', () => {
           et3ResponseHearingRespondent: HearingPreference.NEITHER,
         },
       });
-      request.url = PageUrls.REASONABLE_ADJUSTMENTS;
+      request.url = PageUrls.RESPONDENT_EMPLOYEES;
       updateET3DataMock.mockResolvedValue(mockCaseWithIdWithRespondents);
       await controller.post(request, response);
-      expect(response.redirect).toHaveBeenCalledWith(PageUrls.REASONABLE_ADJUSTMENTS);
+      expect(response.redirect).toHaveBeenCalledWith(PageUrls.RESPONDENT_EMPLOYEES);
     });
   });
 });

--- a/src/test/unit/controllers/RespondentResponseTaskListController.test.ts
+++ b/src/test/unit/controllers/RespondentResponseTaskListController.test.ts
@@ -73,7 +73,9 @@ describe('Respondent response task list controller', () => {
         );
         // checking statuses
         expect(link.status).toBeInstanceOf(Function);
-        expect(link.status(request.t(DefaultValues.STRING_EMPTY))).toBe(expectedRespondentHubTestStatuses[index]);
+        expect(link.status(request.t(DefaultValues.STRING_EMPTY))).toBe(
+          expectedRespondentHubTestStatuses[index][linkIndex]
+        );
       });
     });
     expect(response.render).toHaveBeenCalledWith(
@@ -127,5 +129,40 @@ describe('Respondent response task list controller', () => {
     expect(request.t).toHaveBeenCalledWith(TranslationKeys.COMMON, { returnObjects: true });
     expect(request.t).toHaveBeenCalledWith(TranslationKeys.RESPONDENT_RESPONSE_TASK_LIST, { returnObjects: true });
     expect(request.t).toHaveBeenCalledWith(TranslationKeys.SIDEBAR_CONTACT_US, { returnObjects: true });
+  });
+
+  it('should show Your Support as submitted when respondent external flags exist', async () => {
+    mockWelshFlag.mockResolvedValue(true);
+    const controller = new RespondentResponseTaskListController();
+    const response = mockResponse();
+    const request = mockRequest({
+      session: {
+        userCase: {
+          ...mockUserCaseComplete,
+          respondentExternalFlags: {
+            details: [
+              {
+                id: 'flag-1',
+                value: {},
+              },
+            ],
+          },
+        },
+        user: mockUserDetails,
+      },
+    });
+    request.session.selectedRespondentIndex = 0;
+    (request.t as unknown as jest.Mock).mockReturnValue(mockRespondentHubTranslations);
+
+    await controller.get(request, response);
+
+    const renderMock = response.render as jest.Mock;
+    const sections: Section[] = renderMock.mock.calls[0][1].sections;
+    const yourSupportLink = sections[0].links.find(
+      link => link.linkTxt(mockRespondentHubTranslations) === 'Your Support'
+    );
+
+    expect(yourSupportLink.status(mockRespondentHubTranslations)).toBe('Submitted');
+    expect(yourSupportLink.url()).toBe(PageUrls.YOUR_SUPPORT);
   });
 });

--- a/src/test/unit/controllers/YourSupportController.test.ts
+++ b/src/test/unit/controllers/YourSupportController.test.ts
@@ -1,7 +1,8 @@
 import YourSupportController from '../../../main/controllers/YourSupportController';
+import { YesOrNo } from '../../../main/definitions/case';
 import { PageUrls, TranslationKeys, languages } from '../../../main/definitions/constants';
 import { CaseState } from '../../../main/definitions/definition';
-import { handleUpdateDraftCase } from '../../../main/helpers/CaseHelpers';
+import { handleUpdateDraftCase, handleUpdateSubmittedCaseFlags } from '../../../main/helpers/CaseHelpers';
 import { CUIActions, getCuiService } from '../../../main/services/CuiService';
 import { mockRequest } from '../mocks/mockRequest';
 import { mockResponse } from '../mocks/mockResponse';
@@ -38,10 +39,12 @@ describe('YourSupportController', () => {
         id: '1782812031617616',
         ccdId: '1782812031617616',
         state: CaseState.ACCEPTED,
+        responseReceived: YesOrNo.YES,
         respondents: [
           {
             respondentName: 'Test Respondent',
             ccdId: 'respondent-ccd-id',
+            responseReceived: YesOrNo.YES,
           },
         ],
       },
@@ -115,6 +118,71 @@ describe('YourSupportController', () => {
 
     expect(getJourneyDataMock).toHaveBeenCalledWith('journey-id', { serviceToken: 'service-token' });
     expect(handleUpdateDraftCase).toHaveBeenCalledWith(req, expect.anything());
+    expect(res.redirect).toHaveBeenCalledWith(
+      `${PageUrls.RESPONDENT_RESPONSE_TASK_LIST}${languages.ENGLISH_URL_PARAMETER}`
+    );
+  });
+
+  it('should redirect pre-submitted ET3 CUI callback to respondent response task list', async () => {
+    const getJourneyDataMock = jest.fn().mockResolvedValue({
+      action: CUIActions.SUBMIT,
+      correlationId: '1234',
+      replacementFlags: {
+        partyName: 'Test Respondent',
+        roleOnCase: 'Respondent',
+        details: [
+          {
+            id: 'flag-1',
+            value: {
+              name: 'Support',
+              name_cy: 'Support',
+              dateTimeCreated: '2026-07-14T00:00:00',
+              path: [],
+              hearingRelevant: 'No',
+              flagCode: 'RA0001',
+              availableExternally: 'Yes',
+            },
+          },
+        ],
+      },
+    });
+    (getCuiService as jest.Mock).mockReturnValue({ getJourneyData: getJourneyDataMock });
+    (handleUpdateSubmittedCaseFlags as jest.Mock).mockResolvedValue(undefined);
+
+    const controller = new YourSupportController({
+      getToken: jest.fn().mockResolvedValue('service-token'),
+    } as never);
+    const req = mockRequest({
+      userCase: {
+        id: '1234',
+        state: CaseState.ACCEPTED,
+        responseReceived: YesOrNo.NO,
+        respondents: [
+          {
+            respondentName: 'Test Respondent',
+            ccdId: 'respondent-ccd-id',
+            responseReceived: YesOrNo.NO,
+          },
+        ],
+      },
+      session: {
+        selectedRespondentIndex: 0,
+        user: { accessToken: 'idam-token' },
+      },
+    });
+    req.params = {
+      ...req.params,
+      id: 'journey-id',
+    };
+    req.url = `${PageUrls.YOUR_SUPPORT_CALLBACK.replace(':id', 'journey-id')}${languages.ENGLISH_URL_PARAMETER}`;
+    (req as any).hostname = 'localhost';
+    req.app = { locals: { developmentMode: false } } as never;
+    const res = mockResponse();
+
+    await controller.callback(req, res);
+
+    expect(getJourneyDataMock).toHaveBeenCalledWith('journey-id', { serviceToken: 'service-token' });
+    expect(handleUpdateSubmittedCaseFlags).toHaveBeenCalledWith(req, expect.anything());
     expect(res.redirect).toHaveBeenCalledWith(
       `${PageUrls.RESPONDENT_RESPONSE_TASK_LIST}${languages.ENGLISH_URL_PARAMETER}`
     );

--- a/src/test/unit/controllers/YourSupportController.test.ts
+++ b/src/test/unit/controllers/YourSupportController.test.ts
@@ -1,0 +1,40 @@
+import YourSupportController from '../../../main/controllers/YourSupportController';
+import { TranslationKeys, languages } from '../../../main/definitions/constants';
+import { CaseState } from '../../../main/definitions/definition';
+import { mockRequest } from '../mocks/mockRequest';
+import { mockResponse } from '../mocks/mockResponse';
+
+describe('YourSupportController', () => {
+  it('should render submitted confirmation with a resolved case overview link', async () => {
+    const controller = new YourSupportController();
+    const req = mockRequest({
+      userCase: {
+        id: '1782812031617616',
+        ccdId: '1782812031617616',
+        state: CaseState.ACCEPTED,
+        respondents: [
+          {
+            respondentName: 'Test Respondent',
+            ccdId: 'respondent-ccd-id',
+          },
+        ],
+      },
+      session: {
+        selectedRespondentIndex: 0,
+      },
+    });
+    req.url = `${TranslationKeys.YOUR_SUPPORT_SUBMITTED_CONFIRMATION}${languages.ENGLISH_URL_PARAMETER}`;
+    (req.t as any) = jest.fn().mockReturnValue({});
+    const res = mockResponse();
+
+    await controller.submittedConfirmation(req, res);
+
+    expect(res.render).toHaveBeenCalledWith(
+      TranslationKeys.YOUR_SUPPORT_SUBMITTED_CONFIRMATION,
+      expect.objectContaining({
+        link: `/case-details/1782812031617616/respondent-ccd-id${languages.ENGLISH_URL_PARAMETER}`,
+      })
+    );
+    expect((res.render as jest.Mock).mock.calls[0][1].link).not.toContain(':ccdId');
+  });
+});

--- a/src/test/unit/controllers/YourSupportController.test.ts
+++ b/src/test/unit/controllers/YourSupportController.test.ts
@@ -67,7 +67,7 @@ describe('YourSupportController', () => {
     expect((res.render as jest.Mock).mock.calls[0][1].link).not.toContain(':ccdId');
   });
 
-  it('should redirect draft CUI callback to respondent response task list after saving flags', async () => {
+  it('should redirect draft CUI callback to your support confirmation after saving flags', async () => {
     const getJourneyDataMock = jest.fn().mockResolvedValue({
       action: CUIActions.SUBMIT,
       correlationId: '1234',
@@ -119,11 +119,11 @@ describe('YourSupportController', () => {
     expect(getJourneyDataMock).toHaveBeenCalledWith('journey-id', { serviceToken: 'service-token' });
     expect(handleUpdateDraftCase).toHaveBeenCalledWith(req, expect.anything());
     expect(res.redirect).toHaveBeenCalledWith(
-      `${PageUrls.RESPONDENT_RESPONSE_TASK_LIST}${languages.ENGLISH_URL_PARAMETER}`
+      `${PageUrls.YOUR_SUPPORT_CONFIRMATION}${languages.ENGLISH_URL_PARAMETER}`
     );
   });
 
-  it('should redirect pre-submitted ET3 CUI callback to respondent response task list', async () => {
+  it('should redirect pre-submitted ET3 CUI callback to your support confirmation', async () => {
     const getJourneyDataMock = jest.fn().mockResolvedValue({
       action: CUIActions.SUBMIT,
       correlationId: '1234',
@@ -184,7 +184,40 @@ describe('YourSupportController', () => {
     expect(getJourneyDataMock).toHaveBeenCalledWith('journey-id', { serviceToken: 'service-token' });
     expect(handleUpdateSubmittedCaseFlags).toHaveBeenCalledWith(req, expect.anything());
     expect(res.redirect).toHaveBeenCalledWith(
-      `${PageUrls.RESPONDENT_RESPONSE_TASK_LIST}${languages.ENGLISH_URL_PARAMETER}`
+      `${PageUrls.YOUR_SUPPORT_CONFIRMATION}${languages.ENGLISH_URL_PARAMETER}`
+    );
+  });
+
+  it('should render pre-submitted confirmation with a task list link', async () => {
+    const controller = new YourSupportController();
+    const req = mockRequest({
+      userCase: {
+        id: '1234',
+        state: CaseState.ACCEPTED,
+        responseReceived: YesOrNo.NO,
+        respondents: [
+          {
+            respondentName: 'Test Respondent',
+            ccdId: 'respondent-ccd-id',
+            responseReceived: YesOrNo.NO,
+          },
+        ],
+      },
+      session: {
+        selectedRespondentIndex: 0,
+      },
+    });
+    req.url = `${PageUrls.YOUR_SUPPORT_CONFIRMATION}${languages.ENGLISH_URL_PARAMETER}`;
+    (req.t as any) = jest.fn().mockReturnValue({});
+    const res = mockResponse();
+
+    await controller.confirmation(req, res);
+
+    expect(res.render).toHaveBeenCalledWith(
+      TranslationKeys.YOUR_SUPPORT_CONFIRMATION,
+      expect.objectContaining({
+        link: `${PageUrls.RESPONDENT_RESPONSE_TASK_LIST}${languages.ENGLISH_URL_PARAMETER}`,
+      })
     );
   });
 });

--- a/src/test/unit/controllers/YourSupportController.test.ts
+++ b/src/test/unit/controllers/YourSupportController.test.ts
@@ -1,10 +1,36 @@
 import YourSupportController from '../../../main/controllers/YourSupportController';
-import { TranslationKeys, languages } from '../../../main/definitions/constants';
+import { PageUrls, TranslationKeys, languages } from '../../../main/definitions/constants';
 import { CaseState } from '../../../main/definitions/definition';
+import { handleUpdateDraftCase } from '../../../main/helpers/CaseHelpers';
+import { CUIActions, getCuiService } from '../../../main/services/CuiService';
 import { mockRequest } from '../mocks/mockRequest';
 import { mockResponse } from '../mocks/mockResponse';
 
+jest.mock('../../../main/helpers/CaseHelpers', () => ({
+  handleUpdateDraftCase: jest.fn(),
+  handleUpdateSubmittedCaseFlags: jest.fn(),
+  setUserCase: jest.fn((req, formData) => {
+    req.session.userCase = {
+      ...req.session.userCase,
+      ...formData,
+    };
+  }),
+}));
+
+jest.mock('../../../main/services/CuiService', () => ({
+  CUIActions: {
+    SUBMIT: 'submit',
+    CANCEL: 'cancel',
+  },
+  getCuiService: jest.fn(),
+  mergeCUIFlagItems: jest.fn((existingFlags = [], replacementFlags = []) => [...existingFlags, ...replacementFlags]),
+}));
+
 describe('YourSupportController', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should render submitted confirmation with a resolved case overview link', async () => {
     const controller = new YourSupportController();
     const req = mockRequest({
@@ -36,5 +62,61 @@ describe('YourSupportController', () => {
       })
     );
     expect((res.render as jest.Mock).mock.calls[0][1].link).not.toContain(':ccdId');
+  });
+
+  it('should redirect draft CUI callback to respondent response task list after saving flags', async () => {
+    const getJourneyDataMock = jest.fn().mockResolvedValue({
+      action: CUIActions.SUBMIT,
+      correlationId: '1234',
+      replacementFlags: {
+        partyName: 'Test Respondent',
+        roleOnCase: 'Respondent',
+        details: [
+          {
+            id: 'flag-1',
+            value: {
+              name: 'Support',
+              name_cy: 'Support',
+              dateTimeCreated: '2026-07-14T00:00:00',
+              path: [],
+              hearingRelevant: 'No',
+              flagCode: 'RA0001',
+              availableExternally: 'Yes',
+            },
+          },
+        ],
+      },
+    });
+    (getCuiService as jest.Mock).mockReturnValue({ getJourneyData: getJourneyDataMock });
+    (handleUpdateDraftCase as jest.Mock).mockResolvedValue(undefined);
+
+    const controller = new YourSupportController({
+      getToken: jest.fn().mockResolvedValue('service-token'),
+    } as never);
+    const req = mockRequest({
+      userCase: {
+        id: '1234',
+        state: CaseState.AWAITING_SUBMISSION_TO_HMCTS,
+      },
+      session: {
+        user: { accessToken: 'idam-token' },
+      },
+    });
+    req.params = {
+      ...req.params,
+      id: 'journey-id',
+    };
+    req.url = `${PageUrls.YOUR_SUPPORT_CALLBACK.replace(':id', 'journey-id')}${languages.ENGLISH_URL_PARAMETER}`;
+    (req as any).hostname = 'localhost';
+    req.app = { locals: { developmentMode: false } } as never;
+    const res = mockResponse();
+
+    await controller.callback(req, res);
+
+    expect(getJourneyDataMock).toHaveBeenCalledWith('journey-id', { serviceToken: 'service-token' });
+    expect(handleUpdateDraftCase).toHaveBeenCalledWith(req, expect.anything());
+    expect(res.redirect).toHaveBeenCalledWith(
+      `${PageUrls.RESPONDENT_RESPONSE_TASK_LIST}${languages.ENGLISH_URL_PARAMETER}`
+    );
   });
 });

--- a/src/test/unit/helpers/ApiFormatter.test.ts
+++ b/src/test/unit/helpers/ApiFormatter.test.ts
@@ -370,6 +370,7 @@ describe('Format Case Data to Frontend Model', () => {
       noticeEnds: undefined,
       hearingPreferences: undefined,
       hearingAssistance: undefined,
+      respondentExternalFlags: undefined,
       claimantContactPreference: undefined,
       claimantContactLanguagePreference: undefined,
       claimantHearingLanguagePreference: undefined,

--- a/src/test/unit/helpers/CaseHelpers.test.ts
+++ b/src/test/unit/helpers/CaseHelpers.test.ts
@@ -2,11 +2,16 @@ import axios, { AxiosResponse } from 'axios';
 
 import { Form } from '../../../main/components/form';
 import { CaseApiDataResponse } from '../../../main/definitions/api/caseApiResponse';
-import { CaseWithId } from '../../../main/definitions/case';
+import { CaseFlags, CaseTypeId, CaseWithId } from '../../../main/definitions/case';
 import { DefaultValues, FieldsToReset, GenericTestConstants } from '../../../main/definitions/constants';
 import { CaseState } from '../../../main/definitions/definition';
 import { FormContent, FormFields } from '../../../main/definitions/form';
-import { handleUpdateDraftCase, resetFields, setUserCase } from '../../../main/helpers/CaseHelpers';
+import {
+  handleUpdateDraftCase,
+  handleUpdateSubmittedCaseFlags,
+  resetFields,
+  setUserCase,
+} from '../../../main/helpers/CaseHelpers';
 import * as CaseService from '../../../main/services/CaseService';
 import { CaseApi } from '../../../main/services/CaseService';
 import { isFieldFilledIn } from '../../../main/validators/validator';
@@ -45,6 +50,44 @@ describe('handle update draft case', () => {
     const req = mockRequest({ userCase: undefined, session: mockSession([], [], []) });
     handleUpdateDraftCase(req, mockLogger);
     expect(req.session.userCase).toBeDefined();
+  });
+});
+
+describe('handle update submitted case flags', () => {
+  it('should save submitted case flags without calling the draft update endpoint', async () => {
+    const respondentExternalFlags: CaseFlags = {
+      roleOnCase: 'Respondent',
+      details: [],
+    };
+    caseApi.updateDraftCase = jest.fn();
+    caseApi.updateSubmittedCaseFlags = jest.fn().mockResolvedValueOnce(
+      Promise.resolve({
+        data: {
+          id: '1234',
+          case_type_id: CaseTypeId.ENGLAND_WALES,
+          created_date: '2022-08-19T09:19:25.79202',
+          last_modified: '2022-08-19T09:19:25.817549',
+          state: CaseState.ACCEPTED,
+          case_data: {
+            respondentExternalFlags,
+          },
+        },
+      } as AxiosResponse<CaseApiDataResponse>)
+    );
+    const req = mockRequest({
+      userCase: {
+        id: '1234',
+        caseTypeId: CaseTypeId.ENGLAND_WALES,
+        state: CaseState.ACCEPTED,
+        respondentExternalFlags,
+      },
+    });
+
+    await handleUpdateSubmittedCaseFlags(req, mockLogger);
+
+    expect(caseApi.updateSubmittedCaseFlags).toHaveBeenCalledWith(expect.objectContaining({ respondentExternalFlags }));
+    expect(caseApi.updateDraftCase).not.toHaveBeenCalled();
+    expect(req.session.userCase.respondentExternalFlags).toEqual(respondentExternalFlags);
   });
 });
 

--- a/src/test/unit/helpers/RespondentHubHelper.test.ts
+++ b/src/test/unit/helpers/RespondentHubHelper.test.ts
@@ -44,6 +44,7 @@ describe('getET3HubLinksUrlMap', () => {
 describe('getET3CaseDetailsLinksUrlMap', () => {
   const et3CaseDetailsLinksMapWelsh: Map<string, string> = new Map<string, string>([
     [ET3CaseDetailsLinkNames.PersonalDetails, PageUrls.NOT_IMPLEMENTED + languages.WELSH_URL_PARAMETER],
+    [ET3CaseDetailsLinkNames.YourSupport, PageUrls.YOUR_SUPPORT + languages.WELSH_URL_PARAMETER],
     [ET3CaseDetailsLinkNames.ET1ClaimForm, PageUrls.CLAIMANT_ET1_FORM + languages.WELSH_URL_PARAMETER],
     [ET3CaseDetailsLinkNames.ClaimantContactDetails, PageUrls.CLAIMANT_CONTACT_DETAILS + languages.WELSH_URL_PARAMETER],
     [ET3CaseDetailsLinkNames.RespondentResponse, PageUrls.RESPONDENT_RESPONSE_LANDING + languages.WELSH_URL_PARAMETER],
@@ -64,6 +65,7 @@ describe('getET3CaseDetailsLinksUrlMap', () => {
   ]);
   const et3CaseDetailsLinksMapEnglish: Map<string, string> = new Map<string, string>([
     [ET3CaseDetailsLinkNames.PersonalDetails, PageUrls.NOT_IMPLEMENTED],
+    [ET3CaseDetailsLinkNames.YourSupport, PageUrls.YOUR_SUPPORT],
     [ET3CaseDetailsLinkNames.ET1ClaimForm, PageUrls.CLAIMANT_ET1_FORM],
     [ET3CaseDetailsLinkNames.ClaimantContactDetails, PageUrls.CLAIMANT_CONTACT_DETAILS],
     [ET3CaseDetailsLinkNames.RespondentResponse, PageUrls.RESPONDENT_RESPONSE_LANDING],

--- a/src/test/unit/helpers/controller/CaseDetailsHelper.test.ts
+++ b/src/test/unit/helpers/controller/CaseDetailsHelper.test.ts
@@ -47,7 +47,7 @@ describe('Case Details Helper', () => {
       const statuses: ET3CaseDetailsLinksStatuses = null;
       const result = await getET3CaseDetailsLinkNames(statuses, req);
       expect(result[ET3CaseDetailsLinkNames.PersonalDetails]).toBe(LinkStatus.NOT_YET_AVAILABLE);
-      expect(result[ET3CaseDetailsLinkNames.YourSupport]).toBe(LinkStatus.OPTIONAL);
+      expect(result[ET3CaseDetailsLinkNames.YourSupport]).toBe(LinkStatus.NOT_YET_AVAILABLE);
       expect(result[ET3CaseDetailsLinkNames.ET1ClaimForm]).toBe(LinkStatus.NOT_VIEWED);
       expect(result[ET3CaseDetailsLinkNames.ClaimantContactDetails]).toBe(LinkStatus.READY_TO_VIEW);
       expect(result[ET3CaseDetailsLinkNames.RespondentResponse]).toBe(LinkStatus.NOT_STARTED_YET);
@@ -60,7 +60,7 @@ describe('Case Details Helper', () => {
       const statuses: ET3CaseDetailsLinksStatuses = undefined;
       const result = await getET3CaseDetailsLinkNames(statuses, req);
       expect(result[ET3CaseDetailsLinkNames.PersonalDetails]).toBe(LinkStatus.NOT_YET_AVAILABLE);
-      expect(result[ET3CaseDetailsLinkNames.YourSupport]).toBe(LinkStatus.OPTIONAL);
+      expect(result[ET3CaseDetailsLinkNames.YourSupport]).toBe(LinkStatus.NOT_YET_AVAILABLE);
       expect(result[ET3CaseDetailsLinkNames.ET1ClaimForm]).toBe(LinkStatus.NOT_VIEWED);
       expect(result[ET3CaseDetailsLinkNames.ClaimantContactDetails]).toBe(LinkStatus.READY_TO_VIEW);
       expect(result[ET3CaseDetailsLinkNames.RespondentResponse]).toBe(LinkStatus.NOT_STARTED_YET);
@@ -70,6 +70,7 @@ describe('Case Details Helper', () => {
 
     it('returns SUBMITTED for Your Support when respondent external flags have details', async () => {
       req.session.userCase.genericTseApplicationCollection = [];
+      req.session.userCase.responseReceived = YesOrNo.YES;
       req.session.userCase.respondentExternalFlags = {
         details: [
           {
@@ -89,6 +90,7 @@ describe('Case Details Helper', () => {
 
     it('returns OPTIONAL for Your Support when respondent external flags have no details', async () => {
       req.session.userCase.genericTseApplicationCollection = [];
+      req.session.userCase.responseReceived = YesOrNo.YES;
       req.session.userCase.respondentExternalFlags = {
         details: [],
       };
@@ -97,6 +99,19 @@ describe('Case Details Helper', () => {
       const result = await getET3CaseDetailsLinkNames(statuses, req);
 
       expect(result[ET3CaseDetailsLinkNames.YourSupport]).toBe(LinkStatus.OPTIONAL);
+    });
+
+    it('returns NOT_YET_AVAILABLE for Your Support before the ET3 response is submitted', async () => {
+      req.session.userCase.genericTseApplicationCollection = [];
+      req.session.userCase.responseReceived = YesOrNo.NO;
+      req.session.userCase.respondentExternalFlags = {
+        details: [],
+      };
+      const statuses = {};
+
+      const result = await getET3CaseDetailsLinkNames(statuses, req);
+
+      expect(result[ET3CaseDetailsLinkNames.YourSupport]).toBe(LinkStatus.NOT_YET_AVAILABLE);
     });
 
     it('returns NOT_YET_AVAILABLE when application collection is undefined', async () => {

--- a/src/test/unit/helpers/controller/CaseDetailsHelper.test.ts
+++ b/src/test/unit/helpers/controller/CaseDetailsHelper.test.ts
@@ -28,7 +28,10 @@ describe('Case Details Helper', () => {
     beforeEach(() => {
       req = mockRequest({});
       req.session.user = mockUserDetails;
-      req.session.userCase = mockUserCase;
+      req.session.userCase = {
+        ...mockUserCase,
+        respondentExternalFlags: undefined,
+      };
     });
 
     it('returns NOT_YET_AVAILABLE when no applications exist', async () => {
@@ -63,6 +66,37 @@ describe('Case Details Helper', () => {
       expect(result[ET3CaseDetailsLinkNames.RespondentResponse]).toBe(LinkStatus.NOT_STARTED_YET);
       expect(result[ET3CaseDetailsLinkNames.ContactTribunal]).toBe(LinkStatus.OPTIONAL);
       expect(result[ET3CaseDetailsLinkNames.Documents]).toBe(LinkStatus.OPTIONAL);
+    });
+
+    it('returns SUBMITTED for Your Support when respondent external flags have details', async () => {
+      req.session.userCase.genericTseApplicationCollection = [];
+      req.session.userCase.respondentExternalFlags = {
+        details: [
+          {
+            id: 'flag-1',
+            value: {
+              name: 'Support request',
+            },
+          },
+        ],
+      };
+      const statuses = {};
+
+      const result = await getET3CaseDetailsLinkNames(statuses, req);
+
+      expect(result[ET3CaseDetailsLinkNames.YourSupport]).toBe(LinkStatus.SUBMITTED);
+    });
+
+    it('returns OPTIONAL for Your Support when respondent external flags have no details', async () => {
+      req.session.userCase.genericTseApplicationCollection = [];
+      req.session.userCase.respondentExternalFlags = {
+        details: [],
+      };
+      const statuses = {};
+
+      const result = await getET3CaseDetailsLinkNames(statuses, req);
+
+      expect(result[ET3CaseDetailsLinkNames.YourSupport]).toBe(LinkStatus.OPTIONAL);
     });
 
     it('returns NOT_YET_AVAILABLE when application collection is undefined', async () => {

--- a/src/test/unit/helpers/controller/CaseDetailsHelper.test.ts
+++ b/src/test/unit/helpers/controller/CaseDetailsHelper.test.ts
@@ -2,13 +2,13 @@ import AxiosInstance from 'axios';
 
 import { AppRequest } from '../../../../main/definitions/appRequest';
 import { YesOrNo } from '../../../../main/definitions/case';
-import { Applicant, PartiesNotify, PartiesRespond } from '../../../../main/definitions/constants';
+import { Applicant, PageUrls, PartiesNotify, PartiesRespond } from '../../../../main/definitions/constants';
 import { ET3CaseDetailsLinkNames, ET3CaseDetailsLinksStatuses, LinkStatus } from '../../../../main/definitions/links';
 import { isResponseToTribunalRequired } from '../../../../main/helpers/GenericTseApplicationHelper';
-import { getET3CaseDetailsLinkNames } from '../../../../main/helpers/controller/CaseDetailsHelper';
+import { getET3CaseDetailsLinkNames, getSections } from '../../../../main/helpers/controller/CaseDetailsHelper';
 import { CaseApi } from '../../../../main/services/CaseService';
 import * as CaseService from '../../../../main/services/CaseService';
-import { mockRequest } from '../../mocks/mockRequest';
+import { mockRequest, mockRequestWithTranslation } from '../../mocks/mockRequest';
 import { mockUserDetails } from '../../mocks/mockUser';
 import mockUserCase from '../../mocks/mockUserCase';
 
@@ -44,6 +44,7 @@ describe('Case Details Helper', () => {
       const statuses: ET3CaseDetailsLinksStatuses = null;
       const result = await getET3CaseDetailsLinkNames(statuses, req);
       expect(result[ET3CaseDetailsLinkNames.PersonalDetails]).toBe(LinkStatus.NOT_YET_AVAILABLE);
+      expect(result[ET3CaseDetailsLinkNames.YourSupport]).toBe(LinkStatus.OPTIONAL);
       expect(result[ET3CaseDetailsLinkNames.ET1ClaimForm]).toBe(LinkStatus.NOT_VIEWED);
       expect(result[ET3CaseDetailsLinkNames.ClaimantContactDetails]).toBe(LinkStatus.READY_TO_VIEW);
       expect(result[ET3CaseDetailsLinkNames.RespondentResponse]).toBe(LinkStatus.NOT_STARTED_YET);
@@ -56,6 +57,7 @@ describe('Case Details Helper', () => {
       const statuses: ET3CaseDetailsLinksStatuses = undefined;
       const result = await getET3CaseDetailsLinkNames(statuses, req);
       expect(result[ET3CaseDetailsLinkNames.PersonalDetails]).toBe(LinkStatus.NOT_YET_AVAILABLE);
+      expect(result[ET3CaseDetailsLinkNames.YourSupport]).toBe(LinkStatus.OPTIONAL);
       expect(result[ET3CaseDetailsLinkNames.ET1ClaimForm]).toBe(LinkStatus.NOT_VIEWED);
       expect(result[ET3CaseDetailsLinkNames.ClaimantContactDetails]).toBe(LinkStatus.READY_TO_VIEW);
       expect(result[ET3CaseDetailsLinkNames.RespondentResponse]).toBe(LinkStatus.NOT_STARTED_YET);
@@ -169,6 +171,38 @@ describe('Case Details Helper', () => {
       const statuses = {};
       const result = await getET3CaseDetailsLinkNames(statuses, req);
       expect(result[ET3CaseDetailsLinkNames.OtherRespondentApplications]).toBe(LinkStatus.VIEWED);
+    });
+  });
+
+  describe('getSections', () => {
+    it('adds Your Support under personal details in the first section', () => {
+      const req = mockRequestWithTranslation(
+        {},
+        {
+          section1: 'About you',
+          personalDetails: 'View and edit your personal details',
+          yourSupport: 'Your Support',
+          notAvailableYet: 'Not available yet',
+          optional: 'Optional',
+        }
+      );
+      const selectedRespondent = { et3Status: '' };
+      const statuses = new ET3CaseDetailsLinksStatuses();
+
+      const sections = getSections(statuses, selectedRespondent, req);
+
+      expect(sections[0].links.map(link => link.linkTxt)).toEqual([
+        'View and edit your personal details',
+        'Your Support',
+      ]);
+      expect(sections[0].links[1]).toEqual(
+        expect.objectContaining({
+          linkTxt: 'Your Support',
+          shouldShow: true,
+          status: 'Optional',
+          url: PageUrls.YOUR_SUPPORT,
+        })
+      );
     });
   });
 });

--- a/src/test/unit/helpers/controller/CheckYourAnswersET3Helper.test.ts
+++ b/src/test/unit/helpers/controller/CheckYourAnswersET3Helper.test.ts
@@ -5,7 +5,6 @@ import {
   TypeOfOrganisation,
   YesOrNo,
   YesOrNoOrNotApplicable,
-  YesOrNoOrNotSure,
 } from '../../../../main/definitions/case';
 import { PageUrls } from '../../../../main/definitions/constants';
 import {
@@ -56,7 +55,6 @@ describe('CheckYourAnswersET3Helper', () => {
   // Define URLs for sections 2
   const section2Urls = [
     PageUrls.HEARING_PREFERENCES,
-    PageUrls.REASONABLE_ADJUSTMENTS,
     PageUrls.RESPONDENT_EMPLOYEES,
     PageUrls.RESPONDENT_SITES,
     PageUrls.RESPONDENT_SITE_EMPLOYEES,
@@ -177,7 +175,6 @@ describe('CheckYourAnswersET3Helper', () => {
     }
 
     userCase.et3ResponseHearingRespondent = [HearingPreferenceET3.PHONE];
-    userCase.et3ResponseRespondentSupportNeeded = YesOrNoOrNotSure.NO;
     userCase.et3ResponseRespondentSupportDetails = '';
     userCase.et3ResponseEmploymentCount = '10';
     userCase.et3ResponseMultipleSites = YesOrNo.YES;
@@ -189,10 +186,8 @@ describe('CheckYourAnswersET3Helper', () => {
   });
 
   // Tests for section 2 with POST SELECTED
-  it('should return correct summary list rows for section 2 when all fields are populated POST selected', () => {
+  it('should not include legacy reasonable adjustments rows in section 2', () => {
     const expectedRows: SummaryListRow[] = [];
-
-    section2Urls.splice(2, 0, PageUrls.REASONABLE_ADJUSTMENTS);
 
     for (const pageUrl of section2Urls) {
       expectedRows.push(
@@ -206,7 +201,6 @@ describe('CheckYourAnswersET3Helper', () => {
     }
 
     userCase.et3ResponseHearingRespondent = [HearingPreferenceET3.PHONE];
-    userCase.et3ResponseRespondentSupportNeeded = YesOrNoOrNotSure.YES;
     userCase.et3ResponseRespondentSupportDetails = 'Support Needed';
     userCase.et3ResponseEmploymentCount = '10';
     userCase.et3ResponseMultipleSites = YesOrNo.YES;
@@ -215,6 +209,9 @@ describe('CheckYourAnswersET3Helper', () => {
     const result = getEt3Section2(userCase, translationsMock);
 
     expect(result).toEqual(expectedRows);
+    expect(result).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ key: { text: translationsMock.section2.disabilitySupport } })])
+    );
   });
 
   // Tests for section 3

--- a/src/test/unit/services/CaseService.test.ts
+++ b/src/test/unit/services/CaseService.test.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
-import { CaseTypeId } from '../../../main/definitions/case';
-import { DefaultValues, ET3ModificationTypes, ServiceErrors } from '../../../main/definitions/constants';
+import { CaseFlags, CaseTypeId } from '../../../main/definitions/case';
+import { DefaultValues, ET3ModificationTypes, JavaApiUrls, ServiceErrors } from '../../../main/definitions/constants';
 import { ET3CaseDetailsLinkNames, ET3HubLinkNames, LinkStatus } from '../../../main/definitions/links';
 import { CaseApi, getCaseApi } from '../../../main/services/CaseService';
 import { mockAxiosError } from '../mocks/mockAxios';
@@ -42,6 +42,49 @@ describe('Case Service Tests', () => {
       await expect(() => api.updateDraftCase(mockCaseWithIdWithHubLinkStatuses)).rejects.toEqual(
         new Error(ServiceErrors.ERROR_UPDATING_DRAFT_CASE + ServiceErrors.ERROR_CASE_NOT_FOUND)
       );
+    });
+  });
+
+  describe('Update submitted case flags', () => {
+    it('should only send respondentExternalFlags when updating a submitted case from your support', async () => {
+      const respondentExternalFlags: CaseFlags = {
+        roleOnCase: 'Respondent',
+        details: [],
+      };
+      const caseItem = {
+        ...mockValidCaseWithId,
+        id: '1234',
+        caseTypeId: CaseTypeId.ENGLAND_WALES,
+        respondentExternalFlags,
+      };
+      const mockedAxios = axios as jest.Mocked<typeof axios>;
+      const api = new CaseApi(mockedAxios);
+      mockedAxios.post.mockClear();
+      mockedAxios.post.mockResolvedValueOnce(MockAxiosResponses.mockAxiosResponseWithCaseApiDataResponse);
+
+      await api.updateSubmittedCaseFlags(caseItem);
+
+      expect(mockedAxios.post).toHaveBeenCalledWith(JavaApiUrls.UPDATE_SUBMITTED_CASE, {
+        case_id: '1234',
+        case_type_id: CaseTypeId.ENGLAND_WALES,
+        case_data: {
+          respondentExternalFlags,
+        },
+      });
+    });
+
+    it('should not update submitted case flags without respondentExternalFlags', async () => {
+      const caseItem = {
+        ...mockValidCaseWithId,
+        id: '1234',
+        caseTypeId: CaseTypeId.ENGLAND_WALES,
+      };
+      const mockedAxios = axios as jest.Mocked<typeof axios>;
+      const api = new CaseApi(mockedAxios);
+      mockedAxios.post.mockClear();
+
+      await expect(api.updateSubmittedCaseFlags(caseItem)).rejects.toThrow('respondentExternalFlags must be set');
+      expect(mockedAxios.post).not.toHaveBeenCalled();
     });
   });
 

--- a/src/test/unit/test-helpers/test.constants.ts
+++ b/src/test/unit/test-helpers/test.constants.ts
@@ -8,7 +8,7 @@ export const expectedRespondentHubTestTaskList = {
 };
 
 export const expectedRespondentHubTestLinkTexts = [
-  ['Contact details', 'Hearing format and employer details'],
+  ['Contact details', 'Hearing format and employer details', 'Your Support'],
   ['Early conciliation and employee details', 'Pay, pension and benefits details'],
   ['Contest the claim', "Employer's Contract Claim"],
   ['Check your answers'],
@@ -17,23 +17,24 @@ export const expectedRespondentHubTestLinkTexts = [
 export const sectionTitleTranslationKeys = ['section1', 'section2', 'section3', 'section4'];
 
 export const subSectionTitleTranslationKeys = [
-  ['contactDetails', 'employerDetails'],
+  ['contactDetails', 'employerDetails', 'yourSupport'],
   ['conciliationAndEmployeeDetails', 'payPensionBenefitDetails'],
   ['contestClaim', 'employersContractClaim'],
   ['checkYorAnswers'],
 ];
 
 export const expectedRespondentHubTestStatuses = [
-  'Not started yet',
-  'Not started yet',
-  'Not started yet',
-  'Cannot start yet',
+  ['Not started yet', 'Not started yet', 'Optional'],
+  ['Not started yet', 'Not started yet'],
+  ['Not started yet', 'Not started yet'],
+  ['Cannot start yet'],
 ];
 
 export const mockRespondentHubTranslations = {
   section1: 'Tell us about the respondent',
   contactDetails: 'Contact details',
   employerDetails: 'Hearing format and employer details',
+  yourSupport: 'Your Support',
   section2: 'Tell us about the claimant ',
   conciliationAndEmployeeDetails: 'Early conciliation and employee details',
   payPensionBenefitDetails: 'Pay, pension and benefits details',
@@ -44,4 +45,6 @@ export const mockRespondentHubTranslations = {
   checkYorAnswers: 'Check your answers',
   notStartedYet: 'Not started yet',
   cannotStartYet: 'Cannot start yet',
+  optional: 'Optional',
+  submitted: 'Submitted',
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2079,6 +2079,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@hmcts/cui-client@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@hmcts/cui-client@npm:1.0.0"
+  dependencies:
+    axios: "npm:^1.9.0"
+  checksum: 10/9136153431f8309fcf409264f34a56d107e62a4efb3797f79fdf6781d560a8351d544cbcd4b2dc619cb0d3b4391de0c617626dcfb1fb8aeb9df93b6200240f46
+  languageName: node
+  linkType: hard
+
 "@hmcts/info-provider@npm:^1.3.0":
   version: 1.3.0
   resolution: "@hmcts/info-provider@npm:1.3.0"
@@ -3075,6 +3084,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@noble/hashes@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@noble/hashes@npm:2.2.0"
+  checksum: 10/b1b78bedc2a01394be047429f3d888905015fe8a09f1b7e43e0b5736b54133df62f73dcc73ede43af38e96e86156afb45b86973fdeaa95d9f0880333c3fc0907
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -3233,6 +3249,63 @@ __metadata:
   version: 1.41.1
   resolution: "@opentelemetry/semantic-conventions@npm:1.41.1"
   checksum: 10/3b80fba5b0f28884326966a7b0dfc228c55698531db08834ece2c0ef7537aaaa83cba3f933731c14ffa6b0162b72cc14fee4a0ba68a1858837a590b49be23ee5
+  languageName: node
+  linkType: hard
+
+"@otplib/core@npm:13.4.1":
+  version: 13.4.1
+  resolution: "@otplib/core@npm:13.4.1"
+  checksum: 10/76d56107d702869cbc34724a442e35ee89cd8cf253ce9c75e167b73d27fc2a2f767e96db7d579ff0c03424a4f11b45212261358d73c5bc2be4879a71581c7cb9
+  languageName: node
+  linkType: hard
+
+"@otplib/hotp@npm:13.4.1":
+  version: 13.4.1
+  resolution: "@otplib/hotp@npm:13.4.1"
+  dependencies:
+    "@otplib/core": "npm:13.4.1"
+    "@otplib/uri": "npm:13.4.1"
+  checksum: 10/7949f664eac400b9a50b480fec839d930d5d0b99a1b81abc4fa30a659f952af02825ee4b43634d92505be548d5f3fe88f0bae28e09945494bb99ea5cd99c7f46
+  languageName: node
+  linkType: hard
+
+"@otplib/plugin-base32-scure@npm:13.4.1":
+  version: 13.4.1
+  resolution: "@otplib/plugin-base32-scure@npm:13.4.1"
+  dependencies:
+    "@otplib/core": "npm:13.4.1"
+    "@scure/base": "npm:^2.2.0"
+  checksum: 10/bc2ae6d86499d86e6dbb6d30c12ea28d16165cf8ae60b1d9676cddb115fa9d4090947506d59c90390e6d8e54bcadcd4ac1dc97ea0f74d62a7636fd5a4eb5911b
+  languageName: node
+  linkType: hard
+
+"@otplib/plugin-crypto-noble@npm:13.4.1":
+  version: 13.4.1
+  resolution: "@otplib/plugin-crypto-noble@npm:13.4.1"
+  dependencies:
+    "@noble/hashes": "npm:^2.2.0"
+    "@otplib/core": "npm:13.4.1"
+  checksum: 10/e89cccfd2243de778ba5eb32efe15b3e111bda9f860d40e54a7ff543fb421f121a9a347df8772cc5137a38f6f9af30b0949de43a2ce07cb30971e8d9f7c865c9
+  languageName: node
+  linkType: hard
+
+"@otplib/totp@npm:13.4.1":
+  version: 13.4.1
+  resolution: "@otplib/totp@npm:13.4.1"
+  dependencies:
+    "@otplib/core": "npm:13.4.1"
+    "@otplib/hotp": "npm:13.4.1"
+    "@otplib/uri": "npm:13.4.1"
+  checksum: 10/88b53f3c96dc1a7b2790e606945bc855cdd17e913df70248fa8aa413ef28899907536e90c699bafd8eb3ef680ef08467c58a7fef915b3ab701fb254d254ab160
+  languageName: node
+  linkType: hard
+
+"@otplib/uri@npm:13.4.1":
+  version: 13.4.1
+  resolution: "@otplib/uri@npm:13.4.1"
+  dependencies:
+    "@otplib/core": "npm:13.4.1"
+  checksum: 10/d9b2e230f6558e6c76daa8466b1373195c9f9055a7c5061e395e79894326ebc3d6bd04e1db5ad2be6d110b193d91d1d14f2caecd42b77cbba414c797b4568e63
   languageName: node
   linkType: hard
 
@@ -3563,6 +3636,13 @@ __metadata:
   version: 1.1.0
   resolution: "@rtsao/scc@npm:1.1.0"
   checksum: 10/17d04adf404e04c1e61391ed97bca5117d4c2767a76ae3e879390d6dec7b317fcae68afbf9e98badee075d0b64fa60f287729c4942021b4d19cd01db77385c01
+  languageName: node
+  linkType: hard
+
+"@scure/base@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@scure/base@npm:2.2.0"
+  checksum: 10/b52ec9cd54bad77e22f881b6924ccab692dc1c6dd10287d1787bf263e9f1e560d6d2bda906538fb9a39615d61a1b5c2f53f57a511667fd10e93b9cdaa6fb5d2a
   languageName: node
   linkType: hard
 
@@ -8335,6 +8415,7 @@ __metadata:
     "@codeceptjs/allure-legacy": "npm:^1.0.2"
     "@faker-js/faker": "npm:^9.0.0"
     "@hmcts/cookie-manager": "npm:^1.0.0"
+    "@hmcts/cui-client": "npm:^1.0.0"
     "@hmcts/info-provider": "npm:^1.3.0"
     "@hmcts/nodejs-healthcheck": "npm:^1.8.6"
     "@hmcts/nodejs-logging": "npm:^4.0.4"
@@ -8414,6 +8495,7 @@ __metadata:
     nock: "npm:^14.0.0"
     nodemon: "npm:^3.0.0"
     nunjucks: "npm:^3.2.4"
+    otplib: "npm:^13.4.1"
     pa11y: "npm:^8.0.0"
     path: "npm:^0.12.7"
     playwright: "npm:^1.56.1"
@@ -12854,6 +12936,20 @@ __metadata:
     type-check: "npm:^0.4.0"
     word-wrap: "npm:^1.2.5"
   checksum: 10/a8398559c60aef88d7f353a4f98dcdff6090a4e70f874c827302bf1213d9106a1c4d5fcb68dacb1feb3c30a04c4102f41047aa55d4c576b863d6fc876e001af6
+  languageName: node
+  linkType: hard
+
+"otplib@npm:^13.4.1":
+  version: 13.4.1
+  resolution: "otplib@npm:13.4.1"
+  dependencies:
+    "@otplib/core": "npm:13.4.1"
+    "@otplib/hotp": "npm:13.4.1"
+    "@otplib/plugin-base32-scure": "npm:13.4.1"
+    "@otplib/plugin-crypto-noble": "npm:13.4.1"
+    "@otplib/totp": "npm:13.4.1"
+    "@otplib/uri": "npm:13.4.1"
+  checksum: 10/4556ffba3796894b5497c639b274f0ca7a7974b788138f881a5ca496a2bbbee1d6c22bf872e2af59015e5edca1fbf139ffe3167836f58afe036989bae4800133
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2079,12 +2079,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hmcts/cui-client@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@hmcts/cui-client@npm:1.0.0"
+"@hmcts/cui-client@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@hmcts/cui-client@npm:1.0.1"
   dependencies:
     axios: "npm:^1.9.0"
-  checksum: 10/9136153431f8309fcf409264f34a56d107e62a4efb3797f79fdf6781d560a8351d544cbcd4b2dc619cb0d3b4391de0c617626dcfb1fb8aeb9df93b6200240f46
+  checksum: 10/d3425079aa1390f3c71741c6fa125c051b50c4b86f1a9d4c3f4e7aad62c1187ed6a4f88043b11e25b4ec15dd0106e987486d69bd53986a85e937c89395d5adf9
   languageName: node
   linkType: hard
 
@@ -8415,7 +8415,7 @@ __metadata:
     "@codeceptjs/allure-legacy": "npm:^1.0.2"
     "@faker-js/faker": "npm:^9.0.0"
     "@hmcts/cookie-manager": "npm:^1.0.0"
-    "@hmcts/cui-client": "npm:^1.0.0"
+    "@hmcts/cui-client": "npm:^1.0.1"
     "@hmcts/info-provider": "npm:^1.3.0"
     "@hmcts/nodejs-healthcheck": "npm:^1.8.6"
     "@hmcts/nodejs-logging": "npm:^4.0.4"


### PR DESCRIPTION
### JIRA link

### Change description

Adds a new Your Support flow for reasonable adjustments.
Adds YourSupportController with:start page
CUI journey redirect
CUI callback handling
draft-case save path
submitted-case flag update path
confirmation pages

Adds new Nunjucks views:your-support.njk
your-support-confirmation.njk
your-support-submitted-confirmation.njk

Adds English and Welsh translation files for the new flow.
Adds Your Support links/statuses to:ET3 respondent task list
case details overview

Removes the old reasonable-adjustments step from the hearing-preferences flow:hearing preferences now goes to respondent employees
CYA hearing preferences now routes to Your Support
old disability-support rows are removed from ET3 CYA section 2

Adds CUI integration:CuiService
CUI flag mapping/merge helper
@hmcts/cui-client dependency

Adds S2S token support:S2SService
otplib dependency
S2S serviceName config

Adds submitted-case flag update support:new API URL cases/update-case-submitted
new updateSubmittedCaseFlags API method
new API body type for updating respondentExternalFlags

Adds respondentExternalFlags to case models and API formatter mapping.
Adds getServiceUrl utility for callback/logout URLs.
Updates Helm/config to expose CUI_URL.
Updates Helmet allowlist to include the CUI endpoint.
Adds/updates unit tests for the new controller, services, helpers, formatter, task list, and routing/status behavior.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
