### PR TITLE
fix: add prompt=login to HMCTS Access authorize URL to resolve stale session cookie conflict

### DIFF
--- a/src/main/auth/index.ts
+++ b/src/main/auth/index.ts
@@ -20,9 +20,10 @@ export const getRedirectUrl = (
     ? process.env.IDAM_WEB_URL_HMCTS_ACCESS ?? config.get('services.idam.hmctsAccessURL')
     : process.env.IDAM_WEB_URL ?? config.get('services.idam.authorizationURL');
   const callbackUrl = encodeURI(serviceUrl + callbackUrlPage);
+  const prompt = hmctsAccess ? '&prompt=login' : '';
   return `${loginUrl}?client_id=${clientID}&response_type=code&redirect_uri=${callbackUrl}&state=${guid}&ui_locales=${languageParam}&scope=${encodeURIComponent(
     'openid profile roles'
-  )}`;
+  )}${prompt}`;
 };
 
 export const getUserDetails = async (

--- a/src/test/unit/auth/auth.test.ts
+++ b/src/test/unit/auth/auth.test.ts
@@ -51,7 +51,7 @@ describe('AuthorisationTest', () => {
       );
     });
 
-    test('should use HMCTS Access authorize URL when HMCTS_ACCESS is true', () => {
+    test('should use HMCTS Access authorize URL with prompt=login when HMCTS_ACCESS is true', () => {
       process.env.HMCTS_ACCESS = 'true';
       expect(
         getRedirectUrl(
@@ -61,7 +61,7 @@ describe('AuthorisationTest', () => {
           languages.ENGLISH
         )
       ).toBe(
-        `${hmctsAccessLoginUrl}?client_id=et-syr&response_type=code&redirect_uri=http://localhost/oauth2/callback&state=${AuthorisationTestConstants.GUID}&ui_locales=${languages.ENGLISH}&scope=openid%20profile%20roles`
+        `${hmctsAccessLoginUrl}?client_id=et-syr&response_type=code&redirect_uri=http://localhost/oauth2/callback&state=${AuthorisationTestConstants.GUID}&ui_locales=${languages.ENGLISH}&scope=openid%20profile%20roles&prompt=login`
       );
     });
   });


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RET-6764

## Summary

Adds `prompt=login` to the IDAM `/o/authorize` request when `HMCTS_ACCESS=true` to resolve a stale session cookie conflict that causes a 400 error.

## Problem

When `HMCTS_ACCESS=true`, `et-syr` redirects users to IDAM's `/o/authorize` endpoint (the OAuth2/OIDC flow) instead of the legacy `/login` endpoint.

If a user has previously authenticated with any other HMCTS service that still uses the legacy `/login` flow (e.g. `manage-case.aat.platform.hmcts.net`), their browser holds an `Idam.Session` cookie created by that older flow. When IDAM's `/o/authorize` receives a request with this incompatible session cookie, it fails internally:

```
POST /api/v2/oidc/authorize/code → Unknown error during authorizeCode call
```

IDAM shows its own "There was a problem with your request" error page. The user is never redirected back to `et-syr`, so the existing callback error-handling in `oidc/index.ts` cannot recover.

## Fix

Adding `prompt=login` to the `/o/authorize` request instructs IDAM to ignore any existing session and force fresh authentication. This bypasses the stale cookie without logging the user out of other services (`endSession` was considered but rejected as it destroys the shared IDAM session, logging the user out of everything).

```diff
+ const prompt = hmctsAccess ? '&prompt=login' : '';
  return `${loginUrl}?client_id=...&scope=...${prompt}`;
```

**Scope of impact:**
- Only applies when `HMCTS_ACCESS=true` — the legacy `/login` flow is unaffected
- Users with an existing valid `et-syr` Express session are served from the session cache and never reach IDAM, so they are unaffected
- The trade-off is that OIDC SSO from other HMCTS services into `et-syr` is not used (users must authenticate with et-sya directly), but this is necessary given the session format incompatibility

## Testing

Updated the existing `HMCTS_ACCESS` test to assert `prompt=login` is present in the generated URL.