### PR TITLE
redirect mismatch fix

### DIFF
--- a/playwrighte2e/utils/config.ts
+++ b/playwrighte2e/utils/config.ts
@@ -1,6 +1,6 @@
 export const params = {
   TestUrlCitizenUi: process.env.TEST_URL || 'https://et-sya.aat.platform.hmcts.net',
-  TestUrlRespondentUi: process.env.TEST_URL || process.env.TEST_RESP_URL || 'https://et-syr.aat.platform.hmcts.net',
+  TestUrlRespondentUi: process.env.TEST_RESP_URL || process.env.TEST_URL || 'https://et-syr.aat.platform.hmcts.net',
   TestUrlForManageCaseAAT: process.env.TEST_MANAGE_CASE_URL || 'https://manage-case.aat.platform.hmcts.net',
   TestUrlForManageOrg: process.env.MANAGE_ORG_URL || 'https://manage-org.aat.platform.hmcts.net',
   TestIdamUrl: process.env.IDAM_URL || 'https://idam-api.aat.platform.hmcts.net/testing-support/accounts',


### PR DESCRIPTION
IDAM is rejecting the login because the app’s redirect_uri is not registered for client et-syr.

Detail of the issue:
1. Smoke opens SYR → IDAM login
2. App sends redirect_uri=https://<host-you-hit>/oauth2/callback (from the request host)
3. IDAM compares that to the allow-list for et-syr
4. No match → /auth-error?error=redirect_uri_mismatch → the “Page not found” page you saw

Solution
Put TEST_RESP_URL first rather than env.TEST_URL so that AAT’s registered callback is used.

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:

### JIRA link

### Change description

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
